### PR TITLE
Add modal to register terms

### DIFF
--- a/client/src/components/ConditionsContent.tsx
+++ b/client/src/components/ConditionsContent.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+
+const ConditionsContent = () => (
+  <div className='w-[80%] bg-slate-50 rounded-xl max-h-[90vh] overflow-y-auto p-6 shadow-lg scrollbar-hide'>
+    <h1 className='font-extrabold text-primary md:text-5xl text-4xl p-8'>
+      Les conditions d'utilisation et les status de l'association
+    </h1>
+    <div>
+      <h2 className='md:mt-4  mt-2 md:text-2xl text-xl font-bold'>ARTICLE 1</h2>
+      <p className='mt-8 text-slate-600 text-sm text-justify p-8'>
+        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum deserunt quasi dolore nesciunt error? Sunt, nisi praesentium. Id natus, pariatur asperiores magni ipsum laborum perferendis, eligendi atque tempora cum iste?
+      </p>
+    </div>
+    <div>
+      <h2 className='md:mt-4  mt-2 md:text-2xl text-xl font-bold'>ARTICLE 1</h2>
+      <p className='mt-8 text-slate-600 text-sm text-justify p-8'>
+        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum deserunt quasi dolore nesciunt error? Sunt, nisi praesentium. Id natus, pariatur asperiores magni ipsum laborum perferendis, eligendi atque tempora cum iste?
+      </p>
+    </div>
+    <div>
+      <h2 className='md:mt-4  mt-2 md:text-2xl text-xl font-bold'>ARTICLE 1</h2>
+      <p className='mt-8 text-slate-600 text-sm text-justify p-8'>
+        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum deserunt quasi dolore nesciunt error? Sunt, nisi praesentium. Id natus, pariatur asperiores magni ipsum laborum perferendis, eligendi atque tempora cum iste?
+      </p>
+    </div>
+    <div>
+      <h2 className='md:mt-4  mt-2 md:text-2xl text-xl font-bold'>ARTICLE 1</h2>
+      <p className='mt-8 text-slate-600 text-sm text-justify p-8'>
+        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum deserunt quasi dolore nesciunt error? Sunt, nisi praesentium. Id natus, pariatur asperiores magni ipsum laborum perferendis, eligendi atque tempora cum iste?
+      </p>
+    </div>
+    <div>
+      <h2 className='md:mt-4  mt-2 md:text-2xl text-xl font-bold'>ARTICLE 1</h2>
+      <p className='mt-8 text-slate-600 text-sm text-justify p-8'>
+        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum deserunt quasi dolore nesciunt error? Sunt, nisi praesentium. Id natus, pariatur asperiores magni ipsum laborum perferendis, eligendi atque tempora cum iste?
+      </p>
+    </div>
+    <div>
+      <h2 className='md:mt-4  mt-2 md:text-2xl text-xl font-bold'>ARTICLE 1</h2>
+      <p className='mt-8 text-slate-600 text-sm text-justify p-8'>
+        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum deserunt quasi dolore nesciunt error? Sunt, nisi praesentium. Id natus, pariatur asperiores magni ipsum laborum perferendis, eligendi atque tempora cum iste?
+      </p>
+    </div>
+    <div>
+      <h2 className='md:mt-4  mt-2 md:text-2xl text-xl font-bold'>ARTICLE 1</h2>
+      <p className='mt-8 text-slate-600 text-sm text-justify p-8'>
+        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum deserunt quasi dolore nesciunt error? Sunt, nisi praesentium. Id natus, pariatur asperiores magni ipsum laborum perferendis, eligendi atque tempora cum iste?
+      </p>
+    </div>
+    <div>
+      <h2 className='md:mt-4  mt-2 md:text-2xl text-xl font-bold'>ARTICLE 1</h2>
+      <p className='mt-8 text-slate-600 text-sm text-justify p-8'>
+        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum deserunt quasi dolore nesciunt error? Sunt, nisi praesentium. Id natus, pariatur asperiores magni ipsum laborum perferendis, eligendi atque tempora cum iste?
+      </p>
+    </div>
+    <div>
+      <h2 className='md:mt-4  mt-2 md:text-2xl text-xl font-bold'>ARTICLE 1</h2>
+      <p className='mt-8 text-slate-600 text-sm text-justify p-8'>
+        Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum deserunt quasi dolore nesciunt error? Sunt, nisi praesentium. Id natus, pariatur asperiores magni ipsum laborum perferendis, eligendi atque tempora cum iste?
+      </p>
+    </div>
+  </div>
+)
+
+export default ConditionsContent

--- a/client/src/components/ConditionsModal.tsx
+++ b/client/src/components/ConditionsModal.tsx
@@ -1,0 +1,47 @@
+import { Button } from '@/components/ui/button'
+import CustomModal from '@/components/CustomModal'
+import ConditionsContent from '@/components/ConditionsContent'
+
+type ConditionsModalProps = {
+  open: boolean
+  setOpen: (open: boolean) => void
+  onAccept: () => void
+  onRefuse: () => void
+}
+
+const ConditionsModal = ({ open, setOpen, onAccept, onRefuse }: ConditionsModalProps) => {
+  return (
+    <CustomModal
+      open={open}
+      setOpen={setOpen}
+      title="Conditions d'utilisation"
+      size='xl'
+      footer={(
+        <>
+          <Button
+            variant='destructive'
+            onClick={() => {
+              onRefuse();
+              setOpen(false);
+            }}
+          >
+            Je refuse
+          </Button>
+          <Button
+            variant='default'
+            onClick={() => {
+              onAccept();
+              setOpen(false);
+            }}
+          >
+            J'accepte
+          </Button>
+        </>
+      )}
+    >
+      <ConditionsContent />
+    </CustomModal>
+  )
+}
+
+export default ConditionsModal

--- a/client/src/pages/auth/Register.tsx
+++ b/client/src/pages/auth/Register.tsx
@@ -27,6 +27,7 @@ import { useContext, useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate, useParams } from 'react-router-dom'
+import ConditionsModal from '@/components/ConditionsModal'
 import { z } from 'zod'
 import PasswordGenerator from '@/components/PasswordGenerator'
 import { useGenerateTokenMutation } from '@/hooks/userHooks'
@@ -59,6 +60,7 @@ const Register = () => {
   const { userInfo } = state
   const [conditionsError, setConditionsError] = useState(false)
   const [isOtherInstitution, setIsOtherInstitution] = useState(false)
+  const [showConditionsModal, setShowConditionsModal] = useState(false)
   const navigate = useNavigate()
   const params = useParams()
   const { t } = useTranslation(['common'])
@@ -129,6 +131,15 @@ const Register = () => {
       setConditionsError(false)
       navigate('/origines')
     }
+  }
+
+  const handleAcceptConditions = () => {
+    form.setValue('conditions', true)
+    setConditionsError(false)
+  }
+
+  const handleRefuseConditions = () => {
+    form.setValue('conditions', false)
   }
 
   return (
@@ -383,11 +394,13 @@ const Register = () => {
                         })}
                       >
                         {t('enregistrement.conditions')}&nbsp;
-                        <span className='font-bold'>
-                          <Link to='/conditions'>
-                            {t('enregistrement.status')}
-                          </Link>
-                        </span>
+                        <button
+                          type='button'
+                          onClick={() => setShowConditionsModal(true)}
+                          className='font-bold text-primary underline hover:text-primary/60'
+                        >
+                          {t('enregistrement.status')}
+                        </button>
                       </FormLabel>
                     </FormItem>
                   )}
@@ -407,6 +420,15 @@ const Register = () => {
           </CardFooter>
         </Card>
       </div>
+
+      {showConditionsModal && (
+        <ConditionsModal
+          open={showConditionsModal}
+          setOpen={setShowConditionsModal}
+          onAccept={handleAcceptConditions}
+          onRefuse={handleRefuseConditions}
+        />
+      )}
 
       <Footer />
     </>

--- a/client/src/pages/conditions/Conditions.tsx
+++ b/client/src/pages/conditions/Conditions.tsx
@@ -1,114 +1,12 @@
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
+import ConditionsContent from '@/components/ConditionsContent'
 const Conditions = () => {
   return (
     <>
       <Header />
       <div className='auth flex h-screen items-center justify-center text-center bg-cover bg-center bg-fixed'>
-        <div className='w-[80%] bg-slate-50 rounded-xl max-h-[90vh] overflow-y-auto p-6 shadow-lg scrollbar-hide'>
-          <h1 className='font-extrabold text-primary md:text-5xl text-4xl p-8'>
-            Les conditions d'utilisation et les status de l'association
-          </h1>
-          <div>
-            <h2 className='md:mt-4  mt-2 md:text-2xl text-xl font-bold'>
-              ARTICLE 1
-            </h2>
-            <p className='mt-8 text-slate-600 text-sm text-justify p-8'>
-              Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum
-              deserunt quasi dolore nesciunt error? Sunt, nisi praesentium. Id
-              natus, pariatur asperiores magni ipsum laborum perferendis,
-              eligendi atque tempora cum iste?
-            </p>
-          </div>
-          <div>
-            <h2 className='md:mt-4  mt-2 md:text-2xl text-xl font-bold'>
-              ARTICLE 1
-            </h2>
-            <p className='mt-8 text-slate-600 text-sm text-justify p-8'>
-              Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum
-              deserunt quasi dolore nesciunt error? Sunt, nisi praesentium. Id
-              natus, pariatur asperiores magni ipsum laborum perferendis,
-              eligendi atque tempora cum iste?
-            </p>
-          </div>
-          <div>
-            <h2 className='md:mt-4  mt-2 md:text-2xl text-xl font-bold'>
-              ARTICLE 1
-            </h2>
-            <p className='mt-8 text-slate-600 text-sm text-justify p-8'>
-              Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum
-              deserunt quasi dolore nesciunt error? Sunt, nisi praesentium. Id
-              natus, pariatur asperiores magni ipsum laborum perferendis,
-              eligendi atque tempora cum iste?
-            </p>
-          </div>
-          <div>
-            <h2 className='md:mt-4  mt-2 md:text-2xl text-xl font-bold'>
-              ARTICLE 1
-            </h2>
-            <p className='mt-8 text-slate-600 text-sm text-justify p-8'>
-              Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum
-              deserunt quasi dolore nesciunt error? Sunt, nisi praesentium. Id
-              natus, pariatur asperiores magni ipsum laborum perferendis,
-              eligendi atque tempora cum iste?
-            </p>
-          </div>
-          <div>
-            <h2 className='md:mt-4  mt-2 md:text-2xl text-xl font-bold'>
-              ARTICLE 1
-            </h2>
-            <p className='mt-8 text-slate-600 text-sm text-justify p-8'>
-              Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum
-              deserunt quasi dolore nesciunt error? Sunt, nisi praesentium. Id
-              natus, pariatur asperiores magni ipsum laborum perferendis,
-              eligendi atque tempora cum iste?
-            </p>
-          </div>
-          <div>
-            <h2 className='md:mt-4  mt-2 md:text-2xl text-xl font-bold'>
-              ARTICLE 1
-            </h2>
-            <p className='mt-8 text-slate-600 text-sm text-justify p-8'>
-              Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum
-              deserunt quasi dolore nesciunt error? Sunt, nisi praesentium. Id
-              natus, pariatur asperiores magni ipsum laborum perferendis,
-              eligendi atque tempora cum iste?
-            </p>
-          </div>
-          <div>
-            <h2 className='md:mt-4  mt-2 md:text-2xl text-xl font-bold'>
-              ARTICLE 1
-            </h2>
-            <p className='mt-8 text-slate-600 text-sm text-justify p-8'>
-              Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum
-              deserunt quasi dolore nesciunt error? Sunt, nisi praesentium. Id
-              natus, pariatur asperiores magni ipsum laborum perferendis,
-              eligendi atque tempora cum iste?
-            </p>
-          </div>
-          <div>
-            <h2 className='md:mt-4  mt-2 md:text-2xl text-xl font-bold'>
-              ARTICLE 1
-            </h2>
-            <p className='mt-8 text-slate-600 text-sm text-justify p-8'>
-              Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum
-              deserunt quasi dolore nesciunt error? Sunt, nisi praesentium. Id
-              natus, pariatur asperiores magni ipsum laborum perferendis,
-              eligendi atque tempora cum iste?
-            </p>
-          </div>
-          <div>
-            <h2 className='md:mt-4  mt-2 md:text-2xl text-xl font-bold'>
-              ARTICLE 1
-            </h2>
-            <p className='mt-8 text-slate-600 text-sm text-justify p-8'>
-              Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum
-              deserunt quasi dolore nesciunt error? Sunt, nisi praesentium. Id
-              natus, pariatur asperiores magni ipsum laborum perferendis,
-              eligendi atque tempora cum iste?
-            </p>
-          </div>
-        </div>
+        <ConditionsContent />
       </div>
       <Footer />
     </>


### PR DESCRIPTION
## Summary
- extract reusable ConditionsContent component
- add ConditionsModal component for accepting or refusing terms
- reuse ConditionsContent on conditions page
- open animated modal from Register form and auto-check checkbox on acceptance
- use destructive and primary colors for modal actions

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` in `server` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869b2a29ebc8332a6400e611271bcd7