### PR TITLE
Fix multi-step form persistence

### DIFF
--- a/client/src/pages/auth/Infos.tsx
+++ b/client/src/pages/auth/Infos.tsx
@@ -167,6 +167,16 @@ const Infos = () => {
   }
 
   const handlePreviousClick = () => {
+    const currentValues = form.getValues()
+    ctxDispatch({ type: 'USER_INFOS', payload: currentValues })
+    localStorage.setItem(
+      'userInfo',
+      JSON.stringify({
+        ...userInfo,
+        infos: currentValues,
+        infosTime: new Date(),
+      })
+    )
     navigate(-1)
   }
 

--- a/client/src/pages/auth/Origines.tsx
+++ b/client/src/pages/auth/Origines.tsx
@@ -71,7 +71,6 @@ const Origines = () => {
   const { mutateAsync: upload, isPending: uploadPending } =
     useUploadImageMutation()
   const fileInputRef = useRef<HTMLInputElement>(null)
-  const { logoutHandler } = useContext(Store)
 
   const [idImage, setIdImage] = useState<string>('')
 
@@ -101,6 +100,12 @@ const Origines = () => {
       })
     }
   }, [origines, form])
+
+  useEffect(() => {
+    if (origines?.id_image) {
+      setIdImage(origines.id_image)
+    }
+  }, [origines])
 
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -186,7 +191,19 @@ const Origines = () => {
   }
 
   const handlePreviousClick = () => {
-    logoutHandler()
+    const currentValues = form.getValues()
+    ctxDispatch({
+      type: 'USER_ORIGINES',
+      payload: { ...currentValues, id_image: idImage },
+    })
+    localStorage.setItem(
+      'userInfo',
+      JSON.stringify({
+        ...userInfo,
+        origines: { ...currentValues, id_image: idImage },
+        originesTime: new Date(),
+      })
+    )
     navigate(-1)
   }
 


### PR DESCRIPTION
## Summary
- save form state when moving back from 'Origines' and 'Infos'
- restore uploaded ID image when revisiting the Origines step

## Testing
- `npm run lint` *(fails: ESLint config issue)*
- `npm test` in `server` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869e8052f54833299ee19c92037696d