### PR TITLE
Integrate fees selection into payment page

### DIFF
--- a/client/src/pages/account/PaymentMethod.tsx
+++ b/client/src/pages/account/PaymentMethod.tsx
@@ -1,19 +1,26 @@
 import CreditCardPayment from '@/components/CreditCardPayment'
 import InteracPayment from '@/components/InteracPayment'
+import { useState } from 'react'
+import SelectFees from './SelectFees'
 
 const PaymentMethod = () => {
+  const [showPayment, setShowPayment] = useState(false)
+
   return (
     <>
-      <div className='form flex-col sm:m-0 m-20'>
-        <div className='flex md:flex-row flex-col gap-8 text-center'>
-          <CreditCardPayment />
-          <InteracPayment />
+      <SelectFees onContinue={() => setShowPayment(true)} />
+      {showPayment && (
+        <div className='form flex-col sm:m-0 m-20' id='payment-block'>
+          <div className='flex md:flex-row flex-col gap-8 text-center'>
+            <CreditCardPayment />
+            <InteracPayment />
+          </div>
+          <div className='text-center mt-8'>
+            <h1 className=' text-3xl font-bold'>Mode de paiement</h1>
+            <p>Choisissez par quel moyen vous souhaitez payer votre cotisation</p>
+          </div>
         </div>
-        <div className='text-center mt-8'>
-          <h1 className=' text-3xl font-bold'>Mode de paiement</h1>
-          <p>Choisissez par quel moyen vous souhaitez payer votre cotisation</p>
-        </div>
-      </div>
+      )}
     </>
   )
 }

--- a/client/src/pages/account/SelectFees.tsx
+++ b/client/src/pages/account/SelectFees.tsx
@@ -1,0 +1,70 @@
+import { Checkbox } from '@/components/ui/checkbox'
+import { Button } from '@/components/ui/button'
+import { useState } from 'react'
+
+interface SelectFeesProps {
+  onContinue?: () => void
+}
+const SelectFees = ({ onContinue }: SelectFeesProps) => {
+  const [acq, setAcq] = useState(false)
+  const [transition, setTransition] = useState(false)
+  const [rpn, setRpn] = useState(false)
+
+  const total = (acq ? 50 : 0) + (transition ? 10 : 0) + (rpn ? 20 : 0)
+
+  const continueHandler = () => {
+    if (onContinue) onContinue()
+  }
+
+  return (
+    <div className='container my-8 max-w-lg space-y-6'>
+        <p className='text-center px-4'>
+          Veuillez sélectionner les frais applicables à votre situation en
+          cochant les cases correspondantes ci-dessous. Chaque frais est indiqué
+          avec son montant, et le total sera automatiquement mis à jour selon vos
+          choix. Le total affiché en gras de la page reflète le montant que vous
+          devrez régler. Exemple : si vous sélectionnez les trois cases, le total
+          sera de 80&nbsp;$.
+        </p>
+        <div className='space-y-4 bg-white p-4 rounded shadow'>
+          <div className='flex items-center justify-between'>
+            <div className='flex items-center space-x-2'>
+              <Checkbox id='acq' checked={acq} onCheckedChange={() => setAcq(!acq)} />
+              <label htmlFor='acq' className='text-sm'>
+                Frais d’adhésion à l’ACQ (annuel)
+              </label>
+            </div>
+            <span className='font-medium'>50&nbsp;$</span>
+          </div>
+          <div className='flex items-center justify-between'>
+            <div className='flex items-center space-x-2'>
+              <Checkbox id='transition' checked={transition} onCheckedChange={() => setTransition(!transition)} />
+              <label htmlFor='transition' className='text-sm'>
+                Frais de transition numérique (annuel)
+              </label>
+            </div>
+            <span className='font-medium'>10&nbsp;$</span>
+          </div>
+          <div className='flex items-center justify-between'>
+            <div className='flex items-center space-x-2'>
+              <Checkbox id='rpn' checked={rpn} onCheckedChange={() => setRpn(!rpn)} />
+              <label htmlFor='rpn' className='text-sm'>
+                Frais minimum d’adhésion au RPN (par personne)
+              </label>
+            </div>
+            <span className='font-medium'>20&nbsp;$</span>
+          </div>
+          <div className='text-right font-bold'>Total&nbsp;: {total}&nbsp;$</div>
+          <Button
+            className='w-full'
+            disabled={total === 0}
+            onClick={continueHandler}
+          >
+            Continuer vers le paiement
+          </Button>
+        </div>
+      </div>
+    )
+}
+
+export default SelectFees


### PR DESCRIPTION
## Summary
- include SelectFees component within PaymentMethod page
- remove dedicated /select-fees route and redirect directly to payment step
- pass callback to show payment options when fees are chosen

## Testing
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c70fdb4f48332a6fc03379bd671b4