### PR TITLE
Intégrer SEO seulement sur les pages routées

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,6 +4,19 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Plateforme web de solidarité ACQ-RPN" />
+    <meta
+      name="keywords"
+      content="ACQ-RPN, solidarité, cotisations, annonces de décès"
+    />
+    <meta property="og:title" content="AQC-RPN" />
+    <meta
+      property="og:description"
+      content="Plateforme web de solidarité pour gérer cotisations et annonces de décès."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="http://localhost:3000" />
+    <meta property="og:image" content="/vite.svg" />
     <title>AQC-RPN</title>
   </head>
   <body>

--- a/client/package.json
+++ b/client/package.json
@@ -61,6 +61,7 @@
     "react-day-picker": "^8.10.0",
     "react-dom": "^18.2.0",
     "react-google-charts": "^4.0.1",
+    "react-helmet": "^6.1.0",
     "react-hook-form": "^7.51.1",
     "react-i18next": "^14.1.0",
     "react-redux": "^9.1.0",

--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: /sitemap.xml

--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>http://localhost:3000/</loc>
+  </url>
+</urlset>

--- a/client/src/components/SearchEngineOptimization.tsx
+++ b/client/src/components/SearchEngineOptimization.tsx
@@ -1,0 +1,21 @@
+import { Helmet } from 'react-helmet'
+
+interface SeoProps {
+  title?: string
+  description?: string
+}
+
+export function SearchEngineOptimization({ title, description }: SeoProps) {
+  const pageTitle = title ? `${title} | AQC-RPN` : 'AQC-RPN'
+  const pageDescription =
+    description || 'Plateforme web de solidarit\u00e9 ACQ-RPN'
+
+  return (
+    <Helmet>
+      <title>{pageTitle}</title>
+      <meta name="description" content={pageDescription} />
+      <meta property="og:title" content={pageTitle} />
+      <meta property="og:description" content={pageDescription} />
+    </Helmet>
+  )
+}

--- a/client/src/components/UserHomePage.tsx
+++ b/client/src/components/UserHomePage.tsx
@@ -9,6 +9,7 @@ import TotalDeath from './TotalDeath'
 import { useGetSummaryQuery } from '@/hooks/deathAnnouncementHook'
 import LastAnnouncements from './LastAnnouncements'
 import LastUserTransactions from './LastUserTransactions'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 
 const UserHomPage = () => {
   const { state } = useContext(Store)
@@ -17,6 +18,7 @@ const UserHomPage = () => {
 
   return (
     <>
+      <SearchEngineOptimization title='Résumé' />
       <div className='container mb-10'>
         <h1 className='text-center pt-10 mb-2 text-3xl font-semibold'>
           Bienvenue {userInfo?.origines.firstName}

--- a/client/src/pages/about/About.tsx
+++ b/client/src/pages/about/About.tsx
@@ -1,5 +1,12 @@
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
+
 const About = () => {
-  return <div>About</div>
+  return (
+    <>
+      <SearchEngineOptimization title='About' />
+      <div>About</div>
+    </>
+  )
 }
 
 export default About

--- a/client/src/pages/account-deactivated/AccountDeactivated.tsx
+++ b/client/src/pages/account-deactivated/AccountDeactivated.tsx
@@ -1,14 +1,19 @@
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
+
 const AccountDeactivated = () => {
   return (
-    <div className='text-center py-20'>
-      <h1 className='text-3xl font-bold text-red-600'>Compte désactivé</h1>
-      <p className='mt-4 text-gray-700'>
-        Votre compte a été désactivé suite à une régularisation non effectuée.
-      </p>
-      <p className='mt-2'>
-        Contactez l'administration pour plus d'informations.
-      </p>
-    </div>
+    <>
+      <SearchEngineOptimization title='Compte désactivé' />
+      <div className='text-center py-20'>
+        <h1 className='text-3xl font-bold text-red-600'>Compte désactivé</h1>
+        <p className='mt-4 text-gray-700'>
+          Votre compte a été désactivé suite à une régularisation non effectuée.
+        </p>
+        <p className='mt-2'>
+          Contactez l'administration pour plus d'informations.
+        </p>
+      </div>
+    </>
   )
 }
 

--- a/client/src/pages/account/PaymentMethod.tsx
+++ b/client/src/pages/account/PaymentMethod.tsx
@@ -1,11 +1,13 @@
 import CreditCardPayment from '@/components/CreditCardPayment'
 import InteracPayment from '@/components/InteracPayment'
 import SelectFees from './SelectFees '
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 
 const PaymentMethod = () => {
 
   return (
     <>
+      <SearchEngineOptimization title='Paiement' />
       <SelectFees />
 
       <div className='form flex-col sm:m-0 m-20' id='payment-block' style={{ minHeight: '60vh', justifyContent: 'unset' }}>

--- a/client/src/pages/account/SelectFees .tsx
+++ b/client/src/pages/account/SelectFees .tsx
@@ -67,7 +67,8 @@ export default function SelectFeesWithFamily() {
   const total = useMemo(() => feeDetails.reduce((sum, r) => sum + getSubtotal(r), 0), [feeDetails]);
 
   return (
-    <div className="container mx-auto my-8 max-w-4xl px-4 space-y-8">
+    <>
+      <div className="container mx-auto my-8 max-w-4xl px-4 space-y-8">
       <div className="space-y-4 text-center animate-in fade-in slide-in-from-bottom-2">
         <h2 className="text-xl font-semibold">Instructions de sélection des frais</h2>
         <p>
@@ -177,5 +178,6 @@ export default function SelectFeesWithFamily() {
         <p className="text-lg font-bold">Total : {total} $</p>
       </div>
     </div>
+    </>
   );
 }

--- a/client/src/pages/account/UpdateMethod.tsx
+++ b/client/src/pages/account/UpdateMethod.tsx
@@ -3,6 +3,7 @@ import UpdateInteracPayment from '@/components/UpdateInteracPayment'
 import { useGetAccountsByUserIdQuery } from '@/hooks/accountHooks'
 import { Store } from '@/lib/Store'
 import { useContext } from 'react'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 
 const UpdateMethod = () => {
   const { state } = useContext(Store)
@@ -18,6 +19,7 @@ const UpdateMethod = () => {
 
   return (
     <>
+      <SearchEngineOptimization title='Changer mode de paiement' />
       <div className='form flex-col sm:m-0 m-20'>
         <div className='flex md:flex-row flex-col gap-8 text-center'>
           {accountByUserId &&

--- a/client/src/pages/admin/accounts/Accounts.tsx
+++ b/client/src/pages/admin/accounts/Accounts.tsx
@@ -8,6 +8,7 @@ import ManualDeactivateButton from '@/components/ManualDeactivateButton'
 import ManualReactivateButton from '@/components/ManualReactivateButton'
 import ManualUserPaymentButton from '@/components/ManualUserPaymentButton'
 import { Badge } from '@/components/ui/badge'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 import { Button } from '@/components/ui/button'
 import {
   Form,
@@ -298,6 +299,7 @@ const Accounts = () => {
 
   return (
     <>
+      <SearchEngineOptimization title='Comptes' />
       <div className='container mt-16'>
         <h1 className='text-2xl font-semibold'>Les Comptes</h1>
       </div>

--- a/client/src/pages/admin/announcements/Announcements.tsx
+++ b/client/src/pages/admin/announcements/Announcements.tsx
@@ -34,6 +34,7 @@ import { ArrowUpDown, CalendarIcon, Pencil, Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 
 const formSchema = z.object({
   firstName: z.string(),
@@ -195,6 +196,7 @@ const Announcements = () => {
 
   return (
     <>
+      <SearchEngineOptimization title='Annonces' />
       <div className='container mt-16 flex items-center justify-between'>
         <h1 className='text-2xl font-semibold'>Les Annonces</h1>
         <Button onClick={() => setModalVisibility(true)}>

--- a/client/src/pages/admin/transactions/BilanTransactions.tsx
+++ b/client/src/pages/admin/transactions/BilanTransactions.tsx
@@ -49,7 +49,8 @@ export default function BilanTransactions() {
   const totalAmount = summary?.summary?.[0]?.totalAmount ?? null
 
   return (
-    <div className='flex-1 space-y-4 p-4 md:p-8 pt-6'>
+    <>
+      <div className='flex-1 space-y-4 p-4 md:p-8 pt-6'>
       <div className='flex items-center justify-between'>
         <h2 className='text-3xl font-bold tracking-tight'>
           Tableau de bord financier
@@ -122,5 +123,6 @@ export default function BilanTransactions() {
         </TabsContent>
       </Tabs>
     </div>
+    </>
   )
 }

--- a/client/src/pages/admin/transactions/Transactions.tsx
+++ b/client/src/pages/admin/transactions/Transactions.tsx
@@ -13,6 +13,7 @@ import {
   FormMessage,
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 import {
   Select,
   SelectContent,
@@ -256,6 +257,7 @@ const Transactions = () => {
 
   return (
     <>
+      <SearchEngineOptimization title='Transactions' />
       <div className='container mt-16 flex items-center justify-between'>
         <h1 className='text-2xl font-semibold'>Les Transactions</h1>
         <TransactionPageSubmenu

--- a/client/src/pages/announcements/Announcements.tsx
+++ b/client/src/pages/announcements/Announcements.tsx
@@ -7,6 +7,7 @@ import { functionReverse } from '@/lib/utils'
 import { DeathAnnouncement } from '@/types/DeathAnnouncement'
 import { ColumnDef } from '@tanstack/react-table'
 import { ArrowUpDown } from 'lucide-react'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 
 const AllAnnouncements = () => {
   const { data: announcements, isPending, error } = useGetAnnouncementsQuery()
@@ -60,6 +61,7 @@ const AllAnnouncements = () => {
 
   return (
     <>
+      <SearchEngineOptimization title='Annonces' />
       <div className='container mt-16 flex items-center justify-between'>
         <h1 className='text-2xl font-semibold'>Historique des annonces</h1>
       </div>

--- a/client/src/pages/auth/ForgotPassword.tsx
+++ b/client/src/pages/auth/ForgotPassword.tsx
@@ -6,6 +6,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -58,6 +59,7 @@ const ForgotPassword = () => {
 
   return (
     <>
+      <SearchEngineOptimization title='Mot de passe oublié' />
       <Header />
       <div className='auth form'>
         <Card className='auth-card'>

--- a/client/src/pages/auth/Infos.tsx
+++ b/client/src/pages/auth/Infos.tsx
@@ -8,6 +8,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 import {
   Form,
   FormControl,
@@ -182,6 +183,7 @@ const Infos = () => {
 
   return (
     <>
+      <SearchEngineOptimization title='Infos' />
       <Header />
       <div className='auth form'>
         <Card className='auth-card '>

--- a/client/src/pages/auth/Login.tsx
+++ b/client/src/pages/auth/Login.tsx
@@ -7,6 +7,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -91,6 +92,7 @@ const Login = () => {
 
   return (
     <>
+      <SearchEngineOptimization title='Connexion' />
       <Header />
       <div className='auth form'>
         <Card className='auth-card '>

--- a/client/src/pages/auth/Origines.tsx
+++ b/client/src/pages/auth/Origines.tsx
@@ -10,6 +10,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 import {
   Form,
   FormControl,
@@ -209,6 +210,7 @@ const Origines = () => {
 
   return (
     <>
+      <SearchEngineOptimization title='Origines' />
       <Header />
       <div className='auth form'>
         <Card className='auth-card '>

--- a/client/src/pages/auth/Register.tsx
+++ b/client/src/pages/auth/Register.tsx
@@ -10,6 +10,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
   Form,
@@ -144,6 +145,7 @@ const Register = () => {
 
   return (
     <>
+      <SearchEngineOptimization title='Inscription' />
       <Header />
       <div className='auth form'>
         <Card className='auth-card'>

--- a/client/src/pages/auth/ResetPassword.tsx
+++ b/client/src/pages/auth/ResetPassword.tsx
@@ -9,6 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 import {
   Form,
   FormControl,
@@ -87,6 +88,7 @@ const ResetPassword = () => {
 
   return (
     <>
+      <SearchEngineOptimization title='Réinitialiser mot de passe' />
       <Header />
       <div className='auth'>
         <div className='flex items-center justify-center h-screen'>

--- a/client/src/pages/conditions/Conditions.tsx
+++ b/client/src/pages/conditions/Conditions.tsx
@@ -1,9 +1,11 @@
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import ConditionsContent from '@/components/ConditionsContent'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 const Conditions = () => {
   return (
     <>
+      <SearchEngineOptimization title='Conditions' />
       <Header />
       <div className='auth flex h-screen items-center justify-center text-center bg-cover bg-center bg-fixed'>
         <ConditionsContent />

--- a/client/src/pages/contact/Contact.tsx
+++ b/client/src/pages/contact/Contact.tsx
@@ -1,5 +1,12 @@
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
+
 const Contact = () => {
-  return <div>Contact</div>
+  return (
+    <>
+      <SearchEngineOptimization title='Contact' />
+      <div>Contact</div>
+    </>
+  )
 }
 
 export default Contact

--- a/client/src/pages/home/HomePage.tsx
+++ b/client/src/pages/home/HomePage.tsx
@@ -7,10 +7,12 @@ import RejoinsSection from '@/components/RejoinsSection'
 import BannerSection from '@/components/BannerSection'
 import CardsSection from '@/components/CardsSection'
 import Footer from '@/components/Footer'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 
 const HomePage = () => {
   return (
     <>
+      <SearchEngineOptimization title='Accueil' />
       <Announcement />
       <Navbar />
       <CarouselPlugin />

--- a/client/src/pages/page404/Page404.tsx
+++ b/client/src/pages/page404/Page404.tsx
@@ -1,10 +1,13 @@
 import { Button } from '@/components/ui/button'
 import { useNavigate } from 'react-router-dom'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 
 const Page404 = () => {
   const navigate = useNavigate()
   return (
-    <div className='auth flex h-screen items-center justify-center text-center'>
+    <>
+      <SearchEngineOptimization title='404' />
+      <div className='auth flex h-screen items-center justify-center text-center'>
       <div className='w-[80%]'>
         <h1 className='font-extrabold text-primary md:text-9xl text-4xl'>
           Oops!
@@ -25,6 +28,7 @@ const Page404 = () => {
         </Button>
       </div>
     </div>
+    </>
   )
 }
 

--- a/client/src/pages/profil/Dependents.tsx
+++ b/client/src/pages/profil/Dependents.tsx
@@ -13,6 +13,7 @@ import { FamilyMember } from '@/types/User'
 import { ColumnDef } from '@tanstack/react-table'
 import clsx from 'clsx'
 import { useContext, useEffect, useState } from 'react'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 import { Link } from 'react-router-dom'
 import { ArrowUpDown, Pencil, Trash2, Tally1, CalendarIcon } from 'lucide-react'
 import CustomModal from '@/components/CustomModal'
@@ -318,6 +319,7 @@ const Dependents = () => {
 
   return (
     <>
+      <SearchEngineOptimization title='Personnes à charge' />
       <div className='container mb-10'>
         <h1 className='text-center pt-10 mb-2 text-3xl font-semibold'>
           Bienvenue {userInfo?.origines?.firstName}

--- a/client/src/pages/profil/Profil.tsx
+++ b/client/src/pages/profil/Profil.tsx
@@ -7,6 +7,7 @@ import { Store } from '@/lib/Store'
 import clsx from 'clsx'
 import { useContext } from 'react'
 import { Link } from 'react-router-dom'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 const Profil = () => {
   const { state } = useContext(Store)
   const { userInfo } = state
@@ -14,6 +15,7 @@ const Profil = () => {
 
   return (
     <>
+      <SearchEngineOptimization title='Profil' />
       <div className='container mb-10'>
         <h1 className='text-center pt-10 mb-2 text-3xl font-semibold'>
           Bienvenue {userInfo?.origines?.firstName}

--- a/client/src/pages/profil/Sponsorship.tsx
+++ b/client/src/pages/profil/Sponsorship.tsx
@@ -12,6 +12,7 @@ import clsx from 'clsx'
 import { ArrowUpDown } from 'lucide-react'
 import { useContext } from 'react'
 import { Link } from 'react-router-dom'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 const Sponsorship = () => {
   const { state } = useContext(Store)
   const { userInfo } = state
@@ -76,6 +77,7 @@ const Sponsorship = () => {
   ]
   return (
     <>
+      <SearchEngineOptimization title='Parrainage' />
       {error
         ? toast({
             variant: 'destructive',

--- a/client/src/pages/transactions/Transactions.tsx
+++ b/client/src/pages/transactions/Transactions.tsx
@@ -10,6 +10,7 @@ import { Transaction } from '@/types/Transaction'
 import { ColumnDef } from '@tanstack/react-table'
 import { ArrowUpDown } from 'lucide-react'
 import { useContext } from 'react'
+import { SearchEngineOptimization } from '@/components/SearchEngineOptimization'
 
 const TransactionsByUserId = () => {
   const { state } = useContext(Store)
@@ -78,6 +79,7 @@ const TransactionsByUserId = () => {
   ]
   return (
     <>
+      <SearchEngineOptimization title='Mes transactions' />
       <div className='container mt-16'>
         <h1 className='text-2xl font-semibold'>
           Historique de mes transactions

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -51,6 +51,12 @@ app.get('/api/ping', (_req, res) => {
 })
 
 app.use(express.static(path.join(__dirname, '../dist')))
+app.get('/robots.txt', (_req: Request, res: Response) =>
+  res.sendFile(path.join(__dirname, '../dist/robots.txt'))
+)
+app.get('/sitemap.xml', (_req: Request, res: Response) =>
+  res.sendFile(path.join(__dirname, '../dist/sitemap.xml'))
+)
 app.get('*', (req: Request, res: Response) =>
   res.sendFile(path.join(__dirname, '../dist/index.html'))
 )


### PR DESCRIPTION
## Summary
- retirer SearchEngineOptimization des sous-composants internes
- conserver les balises SEO et le composant pour toutes les pages routées

## Testing
- `npm test --prefix server` *(échoue : module ts-node introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68791f3900d8833280395be19f89bf38