### PR TITLE
Improve toast error messages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,8 @@ import { Button } from './components/ui/button'
 import { useNavigate } from 'react-router-dom'
 import apiClient from './apiClient'
 import { Store } from './lib/Store'
+import { toast } from './components/ui/use-toast'
+import { toastAxiosError } from './lib/utils'
 
 const App = () => {
   const [showButton, setShowButton] = useState(false)
@@ -18,6 +20,8 @@ const App = () => {
         if (error.response && error.response.status === 401) {
           logoutHandler()
           navigate('/login')
+        } else if (error.response && error.response.status === 403) {
+          toastAxiosError(error)
         }
         return Promise.reject(error)
       }

--- a/client/src/components/AddMemberSection.tsx
+++ b/client/src/components/AddMemberSection.tsx
@@ -28,7 +28,7 @@ import {
 } from '@/hooks/userHooks'
 import { toast } from './ui/use-toast'
 import Loading from './Loading'
-import { cn, refresh } from '@/lib/utils'
+import { cn, refresh, toastAxiosError } from '@/lib/utils'
 import { useNavigate } from 'react-router-dom'
 import copy from 'copy-to-clipboard'
 import clsx from 'clsx'
@@ -116,11 +116,7 @@ const AddMemberSection = () => {
       form.reset()
       setModalVisibility(false)
     } catch (error) {
-      toast({
-        variant: 'destructive',
-        title: 'Oops!',
-        description: 'Quelque chose ne va pas.',
-      })
+      toastAxiosError(error)
     }
   }
 

--- a/client/src/components/CreditCardPayment.tsx
+++ b/client/src/components/CreditCardPayment.tsx
@@ -7,7 +7,11 @@ import { expiryDateRegex } from '@/lib/constant'
 import { useContext, useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { formatCreditCardNumber, isDateInFuture } from '@/lib/utils'
+import {
+  formatCreditCardNumber,
+  isDateInFuture,
+  toastAxiosError,
+} from '@/lib/utils'
 import { useNewAccountMutation } from '@/hooks/accountHooks'
 import { Store } from '@/lib/Store'
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -109,11 +113,7 @@ const CreditCardPayment = () => {
         })
       }
     } catch (error) {
-      toast({
-        variant: 'destructive',
-        title: 'Oops!',
-        description: 'Quelque chose ne va pas.',
-      })
+      toastAxiosError(error)
     }
   }
   return (

--- a/client/src/components/InteracPayment.tsx
+++ b/client/src/components/InteracPayment.tsx
@@ -8,7 +8,11 @@ import { Store } from '@/lib/Store'
 import { useNewAccountMutation } from '@/hooks/accountHooks'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { toast } from './ui/use-toast'
-import { refresh, ToLocaleStringFunc } from '@/lib/utils'
+import {
+  refresh,
+  ToLocaleStringFunc,
+  toastAxiosError,
+} from '@/lib/utils'
 import { z } from 'zod'
 import { createInteracFormSchema } from '@/lib/createInteracFormSchema'
 import { useForm } from 'react-hook-form'
@@ -75,11 +79,7 @@ const InteracPayment = ({ total }: InteracPaymentProps) => {
       refresh()
       await newUserNotification(userInfo?.register?.email!)
     } catch (error) {
-      toast({
-        variant: 'destructive',
-        title: 'Oops!',
-        description: 'Quelque chose ne va pas.',
-      })
+      toastAxiosError(error)
     }
   }
 
@@ -121,11 +121,7 @@ const InteracPayment = ({ total }: InteracPaymentProps) => {
       refresh()
       await newUserNotification(userInfo?.register?.email!)
     } catch (error) {
-      toast({
-        variant: 'destructive',
-        title: 'Oops!',
-        description: 'Quelque chose ne va pas.',
-      })
+      toastAxiosError(error)
     }
   }
 

--- a/client/src/components/PaymentMethodInfo.tsx
+++ b/client/src/components/PaymentMethodInfo.tsx
@@ -22,7 +22,11 @@ import { z } from 'zod'
 import { expiryDateRegex } from '@/lib/constant'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { formatCreditCardNumber, isDateInFuture } from '@/lib/utils'
+import {
+  formatCreditCardNumber,
+  isDateInFuture,
+  toastAxiosError,
+} from '@/lib/utils'
 import { toast } from './ui/use-toast'
 import {
   InputOTP,
@@ -141,11 +145,7 @@ const PaymentMethodInfo = () => {
       refetch()
       setAddEditModalVisibility(false)
     } catch (error) {
-      toast({
-        variant: 'destructive',
-        title: 'Oops!',
-        description: 'Quelque chose ne va pas.',
-      })
+      toastAxiosError(error)
     }
   }
 
@@ -178,11 +178,7 @@ const PaymentMethodInfo = () => {
         })
       }
     } catch (error) {
-      toast({
-        variant: 'destructive',
-        title: 'Oops!',
-        description: 'Quelque chose ne va pas.',
-      })
+      toastAxiosError(error)
     }
   }
 

--- a/client/src/components/UpdateCreditCardPayment.tsx
+++ b/client/src/components/UpdateCreditCardPayment.tsx
@@ -6,7 +6,12 @@ import { expiryDateRegex } from '@/lib/constant'
 import { useContext, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { formatCreditCardNumber, isDateInFuture, refresh } from '@/lib/utils'
+import {
+  formatCreditCardNumber,
+  isDateInFuture,
+  refresh,
+  toastAxiosError,
+} from '@/lib/utils'
 import {
   useGetAccountsByUserIdQuery,
   useUpdateAccountMutation,
@@ -98,11 +103,7 @@ const UpdateCreditCardPayment = () => {
         })
       }
     } catch (error) {
-      toast({
-        variant: 'destructive',
-        title: 'Oops!',
-        description: 'Quelque chose ne va pas.',
-      })
+      toastAxiosError(error)
     }
   }
   return (

--- a/client/src/components/UpdateInteracPayment.tsx
+++ b/client/src/components/UpdateInteracPayment.tsx
@@ -25,7 +25,7 @@ import {
 import { Input } from './ui/input'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from './ui/hover-card'
 import { useNewTransactionMutation } from '@/hooks/transactionHooks'
-import { ToLocaleStringFunc } from '@/lib/utils'
+import { ToLocaleStringFunc, toastAxiosError } from '@/lib/utils'
 
 const formSchema = z.object({
   amountInterac: z
@@ -97,11 +97,7 @@ const UpdateInteracPayment = ({
       onSuccess(values.amountInterac)
       setModalVisibility(false)
     } catch (error) {
-      toast({
-        variant: 'destructive',
-        title: 'Oops!',
-        description: 'Quelque chose ne va pas.',
-      })
+      toastAxiosError(error)
     }
   }
 

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,5 +1,7 @@
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
+import axios from 'axios'
+import { toast } from '@/components/ui/use-toast'
 
 export const refresh = () => {
   return window.location.reload()
@@ -161,4 +163,22 @@ export const formatCurrency = (amount: number) => {
 export const formatMonth = (month: number, year: number) => {
   const date = new Date(year, month - 1)
   return date.toLocaleDateString('fr-FR', { month: 'short', year: 'numeric' })
+}
+
+export function extractAxiosErrorMessage(error: unknown): string {
+  if (axios.isAxiosError(error) && error.response && error.response.data) {
+    const message = (error.response.data as { message?: string }).message
+    if (message && String(message).trim().length > 0) {
+      return String(message)
+    }
+  }
+  return 'Quelque chose ne va pas.'
+}
+
+export function toastAxiosError(error: unknown, title = 'Oops!') {
+  toast({
+    variant: 'destructive',
+    title,
+    description: extractAxiosErrorMessage(error),
+  })
 }

--- a/client/src/pages/admin/accounts/Accounts.tsx
+++ b/client/src/pages/admin/accounts/Accounts.tsx
@@ -24,7 +24,11 @@ import {
   useUpdateAccountMutation,
 } from '@/hooks/accountHooks'
 import { Store } from '@/lib/Store'
-import { ToLocaleStringFunc, functionReverse } from '@/lib/utils'
+import {
+  ToLocaleStringFunc,
+  functionReverse,
+  toastAxiosError,
+} from '@/lib/utils'
 import { Account } from '@/types/Account'
 import { User } from '@/types/User'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -304,11 +308,7 @@ const Accounts = () => {
       {isPending ? (
         <Loading />
       ) : error ? (
-        toast({
-          variant: 'destructive',
-          title: 'Oops!',
-          description: 'Quelque chose ne va pas.',
-        })
+        toastAxiosError(error)
       ) : (
         <>
           <div className='container'>

--- a/client/src/pages/admin/announcements/Announcements.tsx
+++ b/client/src/pages/admin/announcements/Announcements.tsx
@@ -24,7 +24,7 @@ import {
   useNewDeathAnnouncementMutation,
   useUpdateAnnouncementMutation,
 } from '@/hooks/deathAnnouncementHook'
-import { cn, functionReverse } from '@/lib/utils'
+import { cn, functionReverse, toastAxiosError } from '@/lib/utils'
 import { DeathAnnouncement } from '@/types/DeathAnnouncement'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { ColumnDef } from '@tanstack/react-table'
@@ -204,11 +204,7 @@ const Announcements = () => {
       {isPending ? (
         <Loading />
       ) : error ? (
-        toast({
-          variant: 'destructive',
-          title: 'Oops!',
-          description: 'Quelque chose ne va pas.',
-        })
+        toastAxiosError(error)
       ) : (
         <div className='mt-5 container'>
           <DataTable data={announcements} columns={columns} />

--- a/client/src/pages/admin/transactions/Transactions.tsx
+++ b/client/src/pages/admin/transactions/Transactions.tsx
@@ -27,7 +27,11 @@ import {
   useUpdateTransactionMutation,
 } from '@/hooks/transactionHooks'
 import { transactionStatus, transactionType } from '@/lib/constant'
-import { functionReverse, ToLocaleStringFunc } from '@/lib/utils'
+import {
+  functionReverse,
+  ToLocaleStringFunc,
+  toastAxiosError,
+} from '@/lib/utils'
 import { Transaction } from '@/types/Transaction'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { ColumnDef } from '@tanstack/react-table'
@@ -102,11 +106,7 @@ const Transactions = () => {
     : []
 
   if (error) {
-    toast({
-      variant: 'destructive',
-      title: 'Oops!',
-      description: 'Quelque chose ne va pas.',
-    })
+    toastAxiosError(error)
     return null
   }
 

--- a/client/src/pages/announcements/Announcements.tsx
+++ b/client/src/pages/announcements/Announcements.tsx
@@ -3,7 +3,7 @@ import Loading from '@/components/Loading'
 import { Button } from '@/components/ui/button'
 import { toast } from '@/components/ui/use-toast'
 import { useGetAnnouncementsQuery } from '@/hooks/deathAnnouncementHook'
-import { functionReverse } from '@/lib/utils'
+import { functionReverse, toastAxiosError } from '@/lib/utils'
 import { DeathAnnouncement } from '@/types/DeathAnnouncement'
 import { ColumnDef } from '@tanstack/react-table'
 import { ArrowUpDown } from 'lucide-react'
@@ -66,11 +66,7 @@ const AllAnnouncements = () => {
       {isPending ? (
         <Loading />
       ) : error ? (
-        toast({
-          variant: 'destructive',
-          title: 'Oops!',
-          description: 'Quelque chose ne va pas.',
-        })
+        toastAxiosError(error)
       ) : (
         <div className='mt-5 container'>
           <DataTable data={announcements} columns={columns} />

--- a/client/src/pages/auth/Infos.tsx
+++ b/client/src/pages/auth/Infos.tsx
@@ -43,7 +43,7 @@ import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import { useRegisterMutation, useVerifyTokenMutation } from '@/hooks/userHooks'
 import Loading from '@/components/Loading'
-import { checkPostalCode, checkTel } from '@/lib/utils'
+import { checkPostalCode, checkTel, toastAxiosError } from '@/lib/utils'
 import { User } from '@/types/User'
 import { toast } from '@/components/ui/use-toast'
 import {
@@ -158,11 +158,7 @@ const Infos = () => {
           description: "L'adresse courriel que vous avez entrer existe déjà",
         })
       } else {
-        toast({
-          variant: 'destructive',
-          title: 'Opps!',
-          description: 'Quelque chose ne va pas.',
-        })
+        toastAxiosError(error, 'Opps!')
       }
     }
   }

--- a/client/src/pages/profil/Dependents.tsx
+++ b/client/src/pages/profil/Dependents.tsx
@@ -49,7 +49,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
-import { cn } from '@/lib/utils'
+import { cn, toastAxiosError } from '@/lib/utils'
 import { format } from 'date-fns'
 import { Calendar } from '@/components/CustomCalendar'
 import IconButtonWithTooltip from '@/components/IconButtonWithTooltip'
@@ -308,11 +308,7 @@ const Dependents = () => {
         refetch()
       }
     } catch (error) {
-      toast({
-        variant: 'destructive',
-        title: 'Oops!',
-        description: 'Quelque chose ne va pas.',
-      })
+      toastAxiosError(error)
     }
   }
 

--- a/client/src/pages/profil/Sponsorship.tsx
+++ b/client/src/pages/profil/Sponsorship.tsx
@@ -11,6 +11,7 @@ import { ColumnDef } from '@tanstack/react-table'
 import clsx from 'clsx'
 import { ArrowUpDown } from 'lucide-react'
 import { useContext } from 'react'
+import { toastAxiosError } from '@/lib/utils'
 import { Link } from 'react-router-dom'
 const Sponsorship = () => {
   const { state } = useContext(Store)
@@ -76,13 +77,7 @@ const Sponsorship = () => {
   ]
   return (
     <>
-      {error
-        ? toast({
-            variant: 'destructive',
-            title: 'Oops!',
-            description: 'Quelque chose ne va pas.',
-          })
-        : ''}
+      {error ? toastAxiosError(error) : ''}
       <div className='container mb-10'>
         <h1 className='text-center pt-10 mb-2 text-3xl font-semibold'>
           Bienvenue {userInfo?.origines.firstName}

--- a/client/src/pages/transactions/Transactions.tsx
+++ b/client/src/pages/transactions/Transactions.tsx
@@ -2,10 +2,13 @@ import { DataTable } from '@/components/CustomTable'
 import Loading from '@/components/Loading'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { toast } from '@/components/ui/use-toast'
 import { useGetTransactionsByUserIdQuery } from '@/hooks/transactionHooks'
 import { Store } from '@/lib/Store'
-import { formatCurrency, functionReverse } from '@/lib/utils'
+import {
+  formatCurrency,
+  functionReverse,
+  toastAxiosError,
+} from '@/lib/utils'
 import { Transaction } from '@/types/Transaction'
 import { ColumnDef } from '@tanstack/react-table'
 import { ArrowUpDown } from 'lucide-react'
@@ -86,11 +89,7 @@ const TransactionsByUserId = () => {
       {isPending ? (
         <Loading />
       ) : error ? (
-        toast({
-          variant: 'destructive',
-          title: 'Oops!',
-          description: 'Quelque chose ne va pas.',
-        })
+        toastAxiosError(error)
       ) : (
         <>
           <div className='container'>


### PR DESCRIPTION
## Summary
- add reusable `toastAxiosError` helper
- display server-provided messages or fallback text when errors occur
- show toast on 403 errors via axios interceptor

## Testing
- `npm test` in `server` *(fails: ERR_REQUIRE_CYCLE_MODULE)*
- `npm test` in `client` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*

------
https://chatgpt.com/codex/tasks/task_e_688c256b633083328ce6e3e0767d44e3