### PR TITLE
feat: add admin toggle action and tests

### DIFF
--- a/client/src/components/ManualToggleAdminButton.tsx
+++ b/client/src/components/ManualToggleAdminButton.tsx
@@ -1,0 +1,52 @@
+import { useToggleAdminMutation } from '@/hooks/userHooks'
+import IconButtonWithTooltip from './IconButtonWithTooltip'
+import { UserPlus, UserMinus } from 'lucide-react'
+import { toast } from './ui/use-toast'
+import { toastAxiosError } from '@/lib/utils'
+
+const ManualToggleAdminButton = ({
+  userId,
+  isAdmin,
+  refetch,
+}: {
+  userId: string
+  isAdmin: boolean
+  refetch: () => void
+}) => {
+  const { mutateAsync: toggleAdmin, isPending } = useToggleAdminMutation()
+
+  const handleClick = async () => {
+    try {
+      await toggleAdmin(userId)
+      refetch()
+      toast({
+        title: isAdmin
+          ? '❎ Administrateur retiré'
+          : '✅ Administrateur ajouté',
+        description: isAdmin
+          ? "L'utilisateur n'est plus administrateur."
+          : "L'utilisateur est désormais administrateur.",
+      })
+    } catch (error) {
+      toastAxiosError(error)
+    }
+  }
+
+  return (
+    <IconButtonWithTooltip
+      icon={
+        isAdmin ? (
+          <UserMinus size={20} className='text-red-600' />
+        ) : (
+          <UserPlus size={20} className='text-blue-600' />
+        )
+      }
+      tooltip={isAdmin ? 'Retirer comme administrateur' : 'Ajouter comme administrateur'}
+      onClick={handleClick}
+      variant='ghost'
+      disabled={isPending}
+    />
+  )
+}
+
+export default ManualToggleAdminButton

--- a/client/src/hooks/userHooks.ts
+++ b/client/src/hooks/userHooks.ts
@@ -167,3 +167,10 @@ export const useReactivateUserMutation = () =>
       console.error('Error reactivating user:', error)
     },
   })
+
+export const useToggleAdminMutation = () =>
+  useMutation({
+    mutationFn: async (userId: string) =>
+      (await apiClient.put<{ message: string }>(`api/users/admin/${userId}`))
+        .data,
+  })

--- a/client/src/pages/admin/accounts/Accounts.tsx
+++ b/client/src/pages/admin/accounts/Accounts.tsx
@@ -7,6 +7,7 @@ import ManualBalanceReminderButton from '@/components/ManualBalanceReminderButto
 import ManualDeactivateButton from '@/components/ManualDeactivateButton'
 import ManualReactivateButton from '@/components/ManualReactivateButton'
 import ManualUserPaymentButton from '@/components/ManualUserPaymentButton'
+import ManualToggleAdminButton from '@/components/ManualToggleAdminButton'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -244,6 +245,12 @@ const Accounts = () => {
             <ManualBalanceReminderButton
               userId={row.original.userId._id}
               disabled={isInactive}
+            />
+            <div className='font-semibold text-[#b9bdbc] mx-2'>|</div>
+            <ManualToggleAdminButton
+              userId={row.original.userId._id}
+              isAdmin={row.original.userId.isAdmin}
+              refetch={refetch}
             />
             <div className='font-semibold text-[#b9bdbc] mx-2'>|</div>
             {row.original.userId.subscription.status === 'inactive' ? (

--- a/client/test/extractAxiosErrorMessage.test.js
+++ b/client/test/extractAxiosErrorMessage.test.js
@@ -1,0 +1,26 @@
+import { test, equal } from 'node:test'
+import { extractAxiosErrorMessage } from '../src/lib/utils.ts'
+
+const inactiveError = {
+  isAxiosError: true,
+  response: { data: { message: "Compte inactif. Veuillez contacter l'administrateur." } },
+}
+
+const genericAxiosError = {
+  isAxiosError: true,
+  response: { data: {} },
+}
+
+test('extractAxiosErrorMessage retourne le message du serveur', () => {
+  equal(
+    extractAxiosErrorMessage(inactiveError),
+    "Compte inactif. Veuillez contacter l'administrateur."
+  )
+})
+
+test("extractAxiosErrorMessage retourne le message par défaut", () => {
+  equal(
+    extractAxiosErrorMessage(genericAxiosError),
+    'Quelque chose ne va pas.'
+  )
+})

--- a/server/src/routers/userRouter.ts
+++ b/server/src/routers/userRouter.ts
@@ -459,3 +459,23 @@ userRouter.put(
     }
   })
 )
+
+userRouter.put(
+  '/admin/:id',
+  isAuth,
+  isAdmin,
+  expressAsyncHandler(async (req: Request, res: Response) => {
+    const user = await UserModel.findById(req.params.id)
+    if (!user) {
+      res.status(404).send({ message: labels.utilisateur.introuvableFr })
+      return
+    }
+    user.isAdmin = !user.isAdmin
+    await user.save()
+    res.send({
+      message: user.isAdmin
+        ? "Utilisateur promu administrateur"
+        : "Utilisateur retiré des administrateurs",
+    })
+  })
+)


### PR DESCRIPTION
## Summary
- allow admins to promote or demote other users
- expose `useToggleAdminMutation` and UI button in account table
- add unit tests for Axios error message extraction

## Testing
- `npm test --prefix client` *(fails: Unknown file extension ".ts" for client/src/lib/utils.ts)*
- `npm test --prefix server` *(fails: Cannot require() ES Module ... in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_688c22cd38cc833293e9d1649f810c20