### PR TITLE
feat: handle pending account payments

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "test": "node --test ./test/*.test.js"
+    "test": "node --experimental-strip-types --test ./test/*.test.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",

--- a/client/src/components/CreditCardPayment.tsx
+++ b/client/src/components/CreditCardPayment.tsx
@@ -93,7 +93,7 @@ const CreditCardPayment = () => {
           userResidenceCountry: userInfo?.infos.residenceCountry!,
           solde: 0,
           paymentMethod: 'credit_card',
-          enAttentePaiement: false,
+          isAwaitingFirstPayment: false, // pour la carte de crédit on s'en fou de savoir si c'est le premier paiement
           userId: userInfo?._id!,
           card: updatedCreditCardTransactions,
         })

--- a/client/src/components/CreditCardPayment.tsx
+++ b/client/src/components/CreditCardPayment.tsx
@@ -93,6 +93,7 @@ const CreditCardPayment = () => {
           userResidenceCountry: userInfo?.infos.residenceCountry!,
           solde: 0,
           paymentMethod: 'credit_card',
+          enAttentePaiement: false,
           userId: userInfo?._id!,
           card: updatedCreditCardTransactions,
         })

--- a/client/src/components/InteracPayment.tsx
+++ b/client/src/components/InteracPayment.tsx
@@ -116,7 +116,6 @@ const InteracPayment = ({ total }: InteracPaymentProps) => {
         const result = await updateAccount({
           ...accountInfo,
           solde: values.amountInterac,
-          paymentMethod: 'interac',
           interac: updatedInteracTransactions,
           isAwaitingFirstPayment: false,
         })
@@ -133,6 +132,7 @@ const InteracPayment = ({ total }: InteracPaymentProps) => {
           userId: userInfo?._id!,
           interac: updatedInteracTransactions,
         })
+        console.log('Updated Account Data 2 :', data)
       }
 
       await newTransaction({

--- a/client/src/components/InteracPayment.tsx
+++ b/client/src/components/InteracPayment.tsx
@@ -85,8 +85,8 @@ const InteracPayment = ({ total }: InteracPaymentProps) => {
         userTel: userInfo?.infos.tel!,
         userResidenceCountry: userInfo?.infos.residenceCountry!,
         solde: 0,
-        paymentMethod: 'enAttentePaiement',
-        enAttentePaiement: true,
+        paymentMethod: 'interac',
+        isAwaitingFirstPayment: true,
         userId: userInfo?._id!,
       })
 
@@ -118,7 +118,7 @@ const InteracPayment = ({ total }: InteracPaymentProps) => {
           solde: values.amountInterac,
           paymentMethod: 'interac',
           interac: updatedInteracTransactions,
-          enAttentePaiement: false,
+          isAwaitingFirstPayment: false,
         })
         data = result.account
       } else {
@@ -129,7 +129,7 @@ const InteracPayment = ({ total }: InteracPaymentProps) => {
           userResidenceCountry: userInfo?.infos.residenceCountry!,
           solde: values.amountInterac,
           paymentMethod: 'interac',
-          enAttentePaiement: false,
+          isAwaitingFirstPayment: false,
           userId: userInfo?._id!,
           interac: updatedInteracTransactions,
         })

--- a/client/src/components/LastUserTransactions.tsx
+++ b/client/src/components/LastUserTransactions.tsx
@@ -73,6 +73,8 @@ const LastUserTransactions = () => {
                           ? 'bg-green-500'
                           : tx.status === 'pending'
                           ? 'bg-yellow-500'
+                          : tx.status === 'awaiting_payment'
+                          ? 'bg-blue-500'
                           : 'bg-red-500'
                       }`}
                     >
@@ -80,6 +82,8 @@ const LastUserTransactions = () => {
                         ? 'Réussie'
                         : tx.status === 'pending'
                         ? 'En attente'
+                        : tx.status === 'awaiting_payment'
+                        ? 'En attente paiement'
                         : 'Échouée'}
                     </Badge>
                   </TableCell>

--- a/client/src/components/PaymentMethodInfo.tsx
+++ b/client/src/components/PaymentMethodInfo.tsx
@@ -134,6 +134,7 @@ const PaymentMethodInfo = () => {
         ...account[0],
         _id: account[0]._id,
         interac: { ...values },
+        enAttentePaiement: false,
       })
       ctxDispatch({ type: 'ACCOUNT_INFOS', payload: data.account })
       localStorage.setItem('accountInfo', JSON.stringify(data.account))
@@ -160,6 +161,7 @@ const PaymentMethodInfo = () => {
           card: {
             ...values,
           },
+          enAttentePaiement: false,
         })
         ctxDispatch({ type: 'ACCOUNT_INFOS', payload: data.account })
         localStorage.setItem('accountInfo', JSON.stringify(data.account))

--- a/client/src/components/PaymentMethodInfo.tsx
+++ b/client/src/components/PaymentMethodInfo.tsx
@@ -134,7 +134,7 @@ const PaymentMethodInfo = () => {
         ...account[0],
         _id: account[0]._id,
         interac: { ...values },
-        enAttentePaiement: false,
+        isAwaitingFirstPayment: false,
       })
       ctxDispatch({ type: 'ACCOUNT_INFOS', payload: data.account })
       localStorage.setItem('accountInfo', JSON.stringify(data.account))
@@ -161,7 +161,7 @@ const PaymentMethodInfo = () => {
           card: {
             ...values,
           },
-          enAttentePaiement: false,
+          isAwaitingFirstPayment: false,
         })
         ctxDispatch({ type: 'ACCOUNT_INFOS', payload: data.account })
         localStorage.setItem('accountInfo', JSON.stringify(data.account))

--- a/client/src/components/UpdateCreditCardPayment.tsx
+++ b/client/src/components/UpdateCreditCardPayment.tsx
@@ -83,7 +83,7 @@ const UpdateCreditCardPayment = () => {
           userResidenceCountry: accountByUserId[0]?.userResidenceCountry ?? '',
           solde: accountByUserId[0]?.solde ?? 0,
           paymentMethod: 'credit_card',
-          enAttentePaiement: false,
+          isAwaitingFirstPayment: false,
           userId: accountByUserId[0]?.userId ?? '',
           _id: accountByUserId[0]?._id ?? '',
           card: updatedCardTransactions,

--- a/client/src/components/UpdateCreditCardPayment.tsx
+++ b/client/src/components/UpdateCreditCardPayment.tsx
@@ -83,6 +83,7 @@ const UpdateCreditCardPayment = () => {
           userResidenceCountry: accountByUserId[0]?.userResidenceCountry ?? '',
           solde: accountByUserId[0]?.solde ?? 0,
           paymentMethod: 'credit_card',
+          enAttentePaiement: false,
           userId: accountByUserId[0]?.userId ?? '',
           _id: accountByUserId[0]?._id ?? '',
           card: updatedCardTransactions,

--- a/client/src/components/UpdateInteracPayment.tsx
+++ b/client/src/components/UpdateInteracPayment.tsx
@@ -77,7 +77,7 @@ const UpdateInteracPayment = ({
         ...accountByUserId?.[0],
         solde: newSolde,
         interac: updatedInteracTransactions,
-        enAttentePaiement: false,
+        isAwaitingFirstPayment: false,
       })
 
       await newTransaction({

--- a/client/src/components/UpdateInteracPayment.tsx
+++ b/client/src/components/UpdateInteracPayment.tsx
@@ -77,6 +77,7 @@ const UpdateInteracPayment = ({
         ...accountByUserId?.[0],
         solde: newSolde,
         interac: updatedInteracTransactions,
+        enAttentePaiement: false,
       })
 
       await newTransaction({

--- a/client/src/components/UserAccountInfo.tsx
+++ b/client/src/components/UserAccountInfo.tsx
@@ -62,13 +62,13 @@ const UserAccountInfo = () => {
           <div className='flex justify-between items-center'>
             <div
               className={`text-3xl font-bold ${
-                isLastTransactionPending ? 'text-gray-400 italic' : ''
+                isLastTransactionPending ? 'text-gray-300 italic' : ''
               }`}
             >
               $&nbsp;{ToLocaleStringFunc(currentSolde ?? 0)}
               {isLastTransactionPending && (
-                <span className='ml-2 text-sm text-muted-foreground'>
-                  (en attente)
+                <span className='ml-1 text-xs text-muted-foreground'>
+                  (en attente approbation)
                 </span>
               )}
             </div>

--- a/client/src/lib/accountUtils.ts
+++ b/client/src/lib/accountUtils.ts
@@ -1,0 +1,5 @@
+export const isEnAttentePaiement = (
+  account?: { enAttentePaiement: boolean; solde: number } | null,
+) => {
+  return !!account && account.enAttentePaiement && account.solde === 0
+}

--- a/client/src/lib/accountUtils.ts
+++ b/client/src/lib/accountUtils.ts
@@ -1,5 +1,0 @@
-export const isEnAttentePaiement = (
-  account?: { enAttentePaiement: boolean; solde: number } | null,
-) => {
-  return !!account && account.enAttentePaiement && account.solde === 0
-}

--- a/client/src/lib/accountValidation.ts
+++ b/client/src/lib/accountValidation.ts
@@ -1,0 +1,5 @@
+export const isAccountPendingPayment = (
+  account?: { isAwaitingFirstPayment: boolean; solde: number } | null,
+) => {
+  return !!account && account.isAwaitingFirstPayment && account.solde === 0
+}

--- a/client/src/lib/accountValidation.ts
+++ b/client/src/lib/accountValidation.ts
@@ -1,5 +1,18 @@
+import { transactionStatus } from '@/lib/constant'
+
 export const isAccountPendingPayment = (
   account?: { isAwaitingFirstPayment: boolean; solde: number } | null,
 ) => {
+  console.log('Account:', account)
   return !!account && account.isAwaitingFirstPayment && account.solde === 0
+}
+
+export const getAccountStatusLabel = (
+  account?: { isAwaitingFirstPayment: boolean; solde: number } | null,
+  lastTransactionStatus?: string,
+): string | null => {
+  if (isAccountPendingPayment(account)) return `(${transactionStatus[3].value})`
+  const status = transactionStatus.find((s) => s.status === lastTransactionStatus)
+  if (status) return `(${status.value})`
+  return null
 }

--- a/client/src/lib/constant.ts
+++ b/client/src/lib/constant.ts
@@ -374,15 +374,20 @@ export const transactionStatus = [
   },
   {
     status: 'pending',
-    value: 'En attente',
+    value: 'En attente approbation',
+  },
+  {
+    status: 'awaiting_payment',
+    value: 'En attente paiement',
   },
 ]
 
 // Couleurs pour le graphique de statut
 export const STATUS_COLOR_MAP: Record<string, string> = {
   Complété: '#34d399',
-  'En attente': '#3b82f6',
+  'En attente approbation': '#3b82f6',
+  'En attente paiement': '#f59e0b',
   Échoué: '#f43f5e',
 }
 
-export const COLORS = ['#0088FE', '#00C49F', '#FF8042']
+export const COLORS = ['#0088FE', '#00C49F', '#FF8042', '#FFBB28']

--- a/client/src/pages/account/PaymentMethod.tsx
+++ b/client/src/pages/account/PaymentMethod.tsx
@@ -16,7 +16,7 @@ const PaymentMethod = () => {
       toast({
         variant: 'destructive',
         title: 'Paiement requis',
-        description: 'veuillez vous aquiter du montant minimum pour être membre',
+        description: 'veuillez vous aquiter du montant minimum pour être membre, sinon des pénalités vous seront appliquées.',
       })
     }
   }, [pending])

--- a/client/src/pages/account/PaymentMethod.tsx
+++ b/client/src/pages/account/PaymentMethod.tsx
@@ -1,11 +1,25 @@
 import CreditCardPayment from '@/components/CreditCardPayment'
 import InteracPayment from '@/components/InteracPayment'
 import SelectFees from './SelectFees'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { SearchEngineOptimization } from '@/components/SearchEngine/SearchEngineOptimization'
+import { useLocation } from 'react-router-dom'
+import { toast } from '@/components/ui/use-toast'
 
 const PaymentMethod = () => {
   const [totalPayment, setTotalPayment] = useState(70)
+  const { search } = useLocation()
+  const pending = new URLSearchParams(search).get('pending')
+
+  useEffect(() => {
+    if (pending) {
+      toast({
+        variant: 'destructive',
+        title: 'Paiement requis',
+        description: 'veuillez vous aquiter du montant minimum pour être membre',
+      })
+    }
+  }, [pending])
 
   return (
     <>

--- a/client/src/pages/admin/transactions/BilanTransactions.tsx
+++ b/client/src/pages/admin/transactions/BilanTransactions.tsx
@@ -10,6 +10,7 @@ import MonthlyPreview from './MonthlyPreview'
 import TransactionStatus from './TransactionStatus'
 import MonthlyTransactionNber from './MonthlyTransactionNber'
 import StatusTransactionDetail from './StatusTransactionDetail'
+import { transactionStatus } from '@/lib/constant'
 
 export default function BilanTransactions() {
   const { data: summary, isPending } = useGetTransactionSummaryQuery()
@@ -34,12 +35,7 @@ export default function BilanTransactions() {
   // Préparer les données pour le graphique de statut
   const statusChartData = summary.statusSummary
     ? summary.statusSummary.map((item: any) => ({
-        name:
-          item._id === 'pending'
-            ? 'En attente'
-            : item._id === 'completed'
-            ? 'Complété'
-            : 'Échoué',
+        name: transactionStatus.find(status => status.status === item._id)?.value || 'Échoué',
         value: item.count,
       }))
     : []

--- a/client/src/pages/admin/transactions/Transactions.tsx
+++ b/client/src/pages/admin/transactions/Transactions.tsx
@@ -51,7 +51,7 @@ const formSchema = z.object({
   amount: z.number().min(0, { message: 'Le montant doit être positif' }),
   type: z.enum(['debit', 'credit']),
   reason: z.string().min(1, { message: 'La raison est requise' }),
-  status: z.enum(['completed', 'failed', 'pending']),
+  status: z.enum(['completed', 'failed', 'pending', 'awaiting_payment']),
 })
 
 const Transactions = () => {
@@ -153,6 +153,13 @@ const Transactions = () => {
           return (
             <Badge className='bg-yellow-500 text-white text-xs'>
               En attente
+            </Badge>
+          )
+        }
+        if (status === 'awaiting_payment') {
+          return (
+            <Badge className='bg-blue-500 text-white text-xs'>
+              En attente paiement
             </Badge>
           )
         }

--- a/client/src/pages/auth/Login.tsx
+++ b/client/src/pages/auth/Login.tsx
@@ -31,6 +31,8 @@ import { Store } from '@/lib/Store'
 import { toast } from '@/components/ui/use-toast'
 import Loading from '@/components/Loading'
 import { SearchEngineOptimization } from '@/components/SearchEngine/SearchEngineOptimization'
+import apiClient from '@/apiClient'
+import { isEnAttentePaiement } from '@/lib/accountUtils'
 
 const Login = () => {
   const { mutateAsync: login, isPending } = useLoginMutation()
@@ -74,7 +76,19 @@ const Login = () => {
         description: 'Connexion réussie',
       })
       localStorage.setItem('userInfo', JSON.stringify(data))
-      navigate(redirect)
+
+      const accountRes = await apiClient.get(`api/accounts/${data._id}/all`)
+      const account = accountRes.data?.[0]
+      if (account) {
+        ctxDispatch({ type: 'ACCOUNT_INFOS', payload: account })
+        localStorage.setItem('accountInfo', JSON.stringify(account))
+      }
+
+      if (isEnAttentePaiement(account)) {
+        navigate('/payment-method?pending=1')
+      } else {
+        navigate(redirect)
+      }
     } catch (error) {
       toast({
         variant: 'destructive',

--- a/client/src/pages/auth/Login.tsx
+++ b/client/src/pages/auth/Login.tsx
@@ -32,7 +32,7 @@ import { toast } from '@/components/ui/use-toast'
 import Loading from '@/components/Loading'
 import { SearchEngineOptimization } from '@/components/SearchEngine/SearchEngineOptimization'
 import apiClient from '@/apiClient'
-import { isEnAttentePaiement } from '@/lib/accountUtils'
+import { isAccountPendingPayment } from '@/lib/accountValidation'
 
 const Login = () => {
   const { mutateAsync: login, isPending } = useLoginMutation()
@@ -84,7 +84,7 @@ const Login = () => {
         localStorage.setItem('accountInfo', JSON.stringify(account))
       }
 
-      if (isEnAttentePaiement(account)) {
+      if (isAccountPendingPayment(account)) {
         navigate('/payment-method?pending=1')
       } else {
         navigate(redirect)

--- a/client/src/types/Account.ts
+++ b/client/src/types/Account.ts
@@ -19,6 +19,7 @@ export type Account = {
   userResidenceCountry: string
   solde: number
   paymentMethod: 'credit_card' | 'interac' | string
+  enAttentePaiement: boolean
   card?: CardType[]
   interac?: Interac[]
   userId: string | any

--- a/client/src/types/Account.ts
+++ b/client/src/types/Account.ts
@@ -19,7 +19,7 @@ export type Account = {
   userResidenceCountry: string
   solde: number
   paymentMethod: 'credit_card' | 'interac' | string
-  enAttentePaiement: boolean
+  isAwaitingFirstPayment: boolean
   card?: CardType[]
   interac?: Interac[]
   userId: string | any

--- a/client/src/types/Transaction.ts
+++ b/client/src/types/Transaction.ts
@@ -5,6 +5,6 @@ export type Transaction = {
   amount: number
   type: 'debit' | 'credit'
   reason: string
-  status: 'completed' | 'failed' | 'pending'
+  status: 'completed' | 'failed' | 'pending' | 'awaiting_payment'
   createdAt?: Date
 }

--- a/client/test/createInteracFormSchema.test.js
+++ b/client/test/createInteracFormSchema.test.js
@@ -1,14 +1,15 @@
-import { test, ok } from 'node:test'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
 import { createInteracFormSchema } from '../src/lib/createInteracFormSchema.ts'
 
 test('amount must be greater than min value', () => {
   const schema = createInteracFormSchema(100)
   const result = schema.safeParse({ amountInterac: 50, refInterac: 'ABCDEFGH' })
-  ok(!result.success)
+  assert.ok(!result.success)
 })
 
 test('accepts amount equal to min', () => {
   const schema = createInteracFormSchema(100)
   const result = schema.safeParse({ amountInterac: 100, refInterac: 'ABCDEFGH' })
-  ok(result.success)
+  assert.ok(result.success)
 })

--- a/client/test/enAttentePaiement.test.js
+++ b/client/test/enAttentePaiement.test.js
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isEnAttentePaiement } from '../src/lib/accountUtils.ts';
+
+const account = {
+  _id: '1',
+  firstName: 'John',
+  lastName: 'Doe',
+  userTel: '123',
+  userResidenceCountry: 'CA',
+  solde: 0,
+  paymentMethod: 'enAttentePaiement',
+  enAttentePaiement: true,
+  userId: '1',
+};
+
+test('returns true when account is pending and solde zero', () => {
+  assert.strictEqual(isEnAttentePaiement(account), true);
+});
+
+test('returns false when solde is positive', () => {
+  assert.strictEqual(isEnAttentePaiement({ ...account, solde: 10 }), false);
+});

--- a/client/test/enAttentePaiement.test.js
+++ b/client/test/enAttentePaiement.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { isEnAttentePaiement } from '../src/lib/accountUtils.ts';
+import { isAccountPendingPayment } from '../src/lib/accountValidation';
 
 const account = {
   _id: '1',
@@ -9,15 +9,15 @@ const account = {
   userTel: '123',
   userResidenceCountry: 'CA',
   solde: 0,
-  paymentMethod: 'enAttentePaiement',
-  enAttentePaiement: true,
+  paymentMethod: 'interact',
+  isAwaitingFirstPayment: true,
   userId: '1',
 };
 
 test('returns true when account is pending and solde zero', () => {
-  assert.strictEqual(isEnAttentePaiement(account), true);
+  assert.strictEqual(isAccountPendingPayment(account), true);
 });
 
 test('returns false when solde is positive', () => {
-  assert.strictEqual(isEnAttentePaiement({ ...account, solde: 10 }), false);
+  assert.strictEqual(isAccountPendingPayment({ ...account, solde: 10 }), false);
 });

--- a/client/test/fees.test.js
+++ b/client/test/fees.test.js
@@ -1,4 +1,5 @@
-import { test, equal } from 'node:test'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
 import { calculateTotal, calculateSubtotal } from '../src/lib/fees.ts'
 
 const sampleRows = [
@@ -8,9 +9,9 @@ const sampleRows = [
 
 test('calculateSubtotal returns expected value', () => {
   const row = { quantity: 2, type: 'adult', isRpnActive: true }
-  equal(calculateSubtotal(row), 140)
+  assert.equal(calculateSubtotal(row), 140)
 })
 
 test('calculateTotal aggregates correctly', () => {
-  equal(calculateTotal(sampleRows), 60 + 10 + 20)
+  assert.equal(calculateTotal(sampleRows), 60 + 10 + 20)
 })

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -24,6 +24,7 @@
         "node-cron": "^3.0.3",
         "nodemailer": "^6.9.13",
         "puppeteer": "^23.11.1",
+        "react-helmet-async": "^2.0.5",
         "streamifier": "^0.1.1"
       },
       "devDependencies": {
@@ -2466,6 +2467,14 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ip-address": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
@@ -2769,6 +2778,17 @@
       "funding": {
         "type": "tidelift",
         "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -3503,6 +3523,36 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
+    "node_modules/react-helmet-async": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-2.0.5.tgz",
+      "integrity": "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -3717,6 +3767,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -27,8 +27,9 @@
     "multer": "^1.4.5-lts.1",
     "node-cron": "^3.0.3",
     "nodemailer": "^6.9.13",
-    "streamifier": "^0.1.1",
-    "puppeteer": "^23.11.1"
+    "puppeteer": "^23.11.1",
+    "react-helmet-async": "^2.0.5",
+    "streamifier": "^0.1.1"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/server/src/models/accountModel.ts
+++ b/server/src/models/accountModel.ts
@@ -45,7 +45,7 @@ export class Account {
   public paymentMethod!: string
 
   @prop({ required: true, default: false })
-  public enAttentePaiement!: boolean
+  public isAwaitingFirstPayment!: boolean
 
   @prop({ type: () => [Card], default: [] })
   public card?: Card[]

--- a/server/src/models/accountModel.ts
+++ b/server/src/models/accountModel.ts
@@ -44,6 +44,9 @@ export class Account {
   @prop({ required: true })
   public paymentMethod!: string
 
+  @prop({ required: true, default: false })
+  public enAttentePaiement!: boolean
+
   @prop({ type: () => [Card], default: [] })
   public card?: Card[]
 

--- a/server/src/models/transactionModel.ts
+++ b/server/src/models/transactionModel.ts
@@ -22,7 +22,7 @@ export class Transaction {
   public reason!: string //e.g "Prélèvement décès"
 
   @prop({ required: true, default: 'completed' })
-  public status!: 'completed' | 'failed' | 'pending'
+  public status!: 'completed' | 'failed' | 'pending' | 'awaiting_payment'
 }
 
 export const TransactionModel = getModelForClass(Transaction)


### PR DESCRIPTION
## Summary
- track enAttentePaiement state on accounts
- handle pay-later flow and payment completion
- redirect pending users to payment page with warning

## Testing
- `cd client && npm test`
- `cd server && npm test` *(fails: Cannot require() ES Module server/test/externalRegistration.test.js in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_6890b089cb58833282350feac6d7e65d