### PR TITLE
feat: adjust membership fees for students

### DIFF
--- a/client/src/lib/fees.ts
+++ b/client/src/lib/fees.ts
@@ -1,4 +1,4 @@
-export type FeeType = 'adult' | 'minor'
+export type FeeType = 'worker' | 'student' | 'minor'
 
 export type FeeDetail = {
   id: string
@@ -8,18 +8,23 @@ export type FeeDetail = {
   isRpnActive: boolean
 }
 
-export const MONTANT_OBLIGATOIRE = {
-  adult: 60,
-  minor: 10,
-} as const
+const BASE_FEES: Record<FeeType, number> = {
+  worker: 65, // 50$ adhésion + 15$ traitement
+  student: 40, // 25$ adhésion + 15$ traitement
+  minor: 15, // 15$ traitement, pas d'adhésion
+}
 
-export const MONTANT_MINIMUM_RPN = 10
+const RPN_FEES: Record<FeeType, number> = {
+  worker: 20,
+  student: 20,
+  minor: 10,
+}
 
 export const calculateSubtotal = (
   row: Pick<FeeDetail, 'quantity' | 'type' | 'isRpnActive'>,
 ): number =>
   row.quantity *
-  (MONTANT_OBLIGATOIRE[row.type] + (row.isRpnActive ? MONTANT_MINIMUM_RPN : 0))
+  (BASE_FEES[row.type] + (row.isRpnActive ? RPN_FEES[row.type] : 0))
 
 export const calculateTotal = (
   rows: Pick<FeeDetail, 'quantity' | 'type' | 'isRpnActive'>[],

--- a/client/src/pages/account/PaymentMethod.tsx
+++ b/client/src/pages/account/PaymentMethod.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import { SearchEngineOptimization } from '@/components/SearchEngine/SearchEngineOptimization'
 
 const PaymentMethod = () => {
-  const [totalPayment, setTotalPayment] = useState(70)
+  const [totalPayment, setTotalPayment] = useState(0)
 
   return (
     <>

--- a/client/test/fees.test.js
+++ b/client/test/fees.test.js
@@ -2,15 +2,15 @@ import { test, equal } from 'node:test'
 import { calculateTotal, calculateSubtotal } from '../src/lib/fees.ts'
 
 const sampleRows = [
-  { quantity: 1, type: 'adult', isRpnActive: true },
+  { quantity: 1, type: 'worker', isRpnActive: true },
   { quantity: 2, type: 'minor', isRpnActive: false },
 ]
 
 test('calculateSubtotal returns expected value', () => {
-  const row = { quantity: 2, type: 'adult', isRpnActive: true }
-  equal(calculateSubtotal(row), 140)
+  const row = { quantity: 2, type: 'worker', isRpnActive: true }
+  equal(calculateSubtotal(row), 170)
 })
 
 test('calculateTotal aggregates correctly', () => {
-  equal(calculateTotal(sampleRows), 60 + 10 + 20)
+  equal(calculateTotal(sampleRows), 85 + 30)
 })

--- a/server/src/models/settingsModel.ts
+++ b/server/src/models/settingsModel.ts
@@ -9,8 +9,8 @@ export class Settings {
   @prop({ required: true, default: 10 })
   public amountPerDependent!: number
 
-  // Montant annuel par personne pour conserver le statut de membre (par personne ≥ 18 ans)
-  @prop({ required: true, default: 10 })
+  // Montant annuel pour un adulte travailleur
+  @prop({ required: true, default: 50 })
   public membershipUnitAmount!: number
 
   // Solde minimum requis pour ne pas recevoir d’alerte (RPN)


### PR DESCRIPTION
## Summary
- calculate membership costs per occupation
- adjust fee selection to charge students $25 vs $50 for workers
- default payment amount derives from selected fees

## Testing
- `npm test` (fails: unknown file extension .ts)
- `npm test` (server, fails: ERR_REQUIRE_CYCLE_MODULE)
- `node --loader ts-node/esm --test ./test/*.test.js` (fails: cannot find package 'ts-node')
- `npm install --no-save ts-node` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_6890b7b4e81c8332bba8945f6cf80eb1