### PR TITLE
feat: enforce first payment before accessing app

### DIFF
--- a/client/src/components/InteracPayment.tsx
+++ b/client/src/components/InteracPayment.tsx
@@ -213,7 +213,7 @@ const InteracPayment = ({ total }: InteracPaymentProps) => {
                     <FormLabel className='text-sm'>
                       Numéro de référence du transfert Interac
                       <HoverCard>
-                        <HoverCardTrigger className='cursor-pointer italic text-xs hover:underline'>
+                        <HoverCardTrigger className="cursor-pointer italic text-xs hover:underline ml-1 animate-pulse">
                           (où le trouver)
                         </HoverCardTrigger>
                         <HoverCardContent className='font-light text-justify'>

--- a/client/src/components/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute.tsx
@@ -1,14 +1,28 @@
 import { Store } from '@/lib/Store'
-import { useContext } from 'react'
+import { useContext, useEffect } from 'react'
 import { Navigate, Outlet } from 'react-router-dom'
 import Header from './Header'
 import Footer from './Footer'
 import Announcement from './Announcement'
+import { useGetAccountsByUserIdQuery } from '@/hooks/accountHooks'
+import useAwaitingFirstPaymentRedirect from '@/hooks/useAwaitingFirstPaymentRedirect'
 
 const ProtectedRoute = () => {
   const {
     state: { userInfo },
+    dispatch: ctxDispatch,
   } = useContext(Store)
+
+  const { data: accounts } = useGetAccountsByUserIdQuery(userInfo?._id)
+  const account = accounts?.[0]
+  useAwaitingFirstPaymentRedirect(account)
+
+  useEffect(() => {
+    if (account) {
+      ctxDispatch({ type: 'ACCOUNT_INFOS', payload: account })
+      localStorage.setItem('accountInfo', JSON.stringify(account))
+    }
+  }, [account, ctxDispatch])
 
   if (!userInfo) return <Navigate to='/login' />
   if (userInfo?.subscription?.status === 'inactive') {

--- a/client/src/components/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute.tsx
@@ -9,20 +9,21 @@ import useAwaitingFirstPaymentRedirect from '@/hooks/useAwaitingFirstPaymentRedi
 
 const ProtectedRoute = () => {
   const {
-    state: { userInfo },
+    state: { userInfo, accountInfo },
     dispatch: ctxDispatch,
   } = useContext(Store)
 
   const { data: accounts } = useGetAccountsByUserIdQuery(userInfo?._id)
-  const account = accounts?.[0]
-  useAwaitingFirstPaymentRedirect(account)
+  const fetchedAccount = accounts?.[accounts.length - 1]
+
+  useAwaitingFirstPaymentRedirect(accountInfo)
 
   useEffect(() => {
-    if (account) {
-      ctxDispatch({ type: 'ACCOUNT_INFOS', payload: account })
-      localStorage.setItem('accountInfo', JSON.stringify(account))
+    if (fetchedAccount) {
+      ctxDispatch({ type: 'ACCOUNT_INFOS', payload: fetchedAccount })
+      localStorage.setItem('accountInfo', JSON.stringify(fetchedAccount))
     }
-  }, [account, ctxDispatch])
+  }, [fetchedAccount, ctxDispatch])
 
   if (!userInfo) return <Navigate to='/login' />
   if (userInfo?.subscription?.status === 'inactive') {

--- a/client/src/components/UpdateInteracPayment.tsx
+++ b/client/src/components/UpdateInteracPayment.tsx
@@ -78,13 +78,8 @@ const UpdateInteracPayment = ({ onSuccess, minAmount = 25 }: UpdateInteracPaymen
 
       ctxDispatch({ type: 'ACCOUNT_INFOS', payload: data.account })
       localStorage.setItem('accountInfo', JSON.stringify(data.account))
-      toast({
-        variant: 'default',
-        title: 'Moyen de paiement',
-        description: `N'oubliez pas de faire le transfert Interac.`,
-      })
+      
       onSuccess(values.amountInterac)
-      navigate('/summary')
       setModalVisibility(false)
     } catch (error) {
       toastAxiosError(error)

--- a/client/src/components/UpdateInteracPayment.tsx
+++ b/client/src/components/UpdateInteracPayment.tsx
@@ -27,37 +27,30 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from './ui/hover-card'
 import { useNewTransactionMutation } from '@/hooks/transactionHooks'
 import { ToLocaleStringFunc, toastAxiosError } from '@/lib/utils'
 
-const formSchema = z.object({
-  amountInterac: z
-    .number({
-      required_error: 'Le montant ne peut-être inférieur à 25$',
-      invalid_type_error: 'Le montant doit être un nombre.',
-    })
-    .gte(25),
-  refInterac: z
-    .string()
-    .min(8, { message: 'Doit avoir au moins 8 charactères.' }),
-})
+// 👇 utilise le même générateur de schéma que InteracPayment pour un rendu/validation identiques
+import { createInteracFormSchema } from '@/lib/createInteracFormSchema'
+import { useNavigate } from 'react-router-dom'
 
-const UpdateInteracPayment = ({
-  onSuccess,
-}: {
+type UpdateInteracPaymentProps = {
   onSuccess: (amount: number) => void
-}) => {
+  minAmount?: number
+}
+
+const UpdateInteracPayment = ({ onSuccess, minAmount = 25 }: UpdateInteracPaymentProps) => {
   const [modalVisibility, setModalVisibility] = useState(false)
   const { state, dispatch: ctxDispatch } = useContext(Store)
+    const navigate = useNavigate()
   const { userInfo } = state
-  const { data: accountByUserId } = useGetAccountsByUserIdQuery(
-    userInfo?._id ?? ''
-  )
+  const { data: accountByUserId } = useGetAccountsByUserIdQuery(userInfo?._id ?? '')
   const { mutateAsync: updateAccount, isPending } = useUpdateAccountMutation()
   const { mutateAsync: newTransaction } = useNewTransactionMutation()
 
+  const formSchema = createInteracFormSchema(minAmount)
   const form = useForm<z.infer<typeof formSchema>>({
     mode: 'onChange',
     resolver: zodResolver(formSchema),
     defaultValues: {
-      amountInterac: 0,
+      amountInterac: minAmount,
       refInterac: '',
     },
   })
@@ -65,12 +58,7 @@ const UpdateInteracPayment = ({
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     try {
       const existingInteracTransactions = accountByUserId?.[0]?.interac ?? []
-      const newInteracTransaction = { ...values }
-      const updatedInteracTransactions = [
-        ...existingInteracTransactions,
-        newInteracTransaction,
-      ]
-
+      const updatedInteracTransactions = [...existingInteracTransactions, { ...values }]
       const newSolde = (accountByUserId?.[0]?.solde ?? 0) + values.amountInterac
 
       const data = await updateAccount({
@@ -96,6 +84,7 @@ const UpdateInteracPayment = ({
         description: `N'oubliez pas de faire le transfert Interac.`,
       })
       onSuccess(values.amountInterac)
+      navigate('/summary')
       setModalVisibility(false)
     } catch (error) {
       toastAxiosError(error)
@@ -107,12 +96,12 @@ const UpdateInteracPayment = ({
       <motion.div whileHover={{ scale: 1.2 }}>
         <Card
           onClick={() => setModalVisibility(true)}
-          className='w-[250px] cursor-pointer bg-sky-400 text-white'
+          className="w-[250px] cursor-pointer bg-sky-400 text-white"
         >
-          <CardContent className='flex justify-center items-center aspect-square p-6'>
+          <CardContent className="flex justify-center items-center aspect-square p-6">
             {isPending ? <Loading /> : <ArrowRightLeft size={50} />}
           </CardContent>
-          <CardFooter className='flex justify-center font-semibold'>
+          <CardFooter className="flex justify-center font-semibold">
             Paiement via Interac
           </CardFooter>
         </Card>
@@ -120,26 +109,31 @@ const UpdateInteracPayment = ({
 
       {modalVisibility ? (
         <CustomModal
-          setOpen={() => {
-            setModalVisibility(false)
-          }}
+          setOpen={() => setModalVisibility(false)}
           open={modalVisibility}
-          title='Paiement Interac'
-          description={`Faire le virement Interac à l'adresse courriel suivante "paiement.rpn@gmail.com" et utiliser le mot de passe suivant "monrpn" si demandé.
-Par la suite entrez les informations du virement que vous avez effectuer pour renflouer votre compte RPN.(le montant ne peut-être inférieur à 25$)`}
+          title="Faire un paiement Interac"
+          description={
+            <span className="block text-justify">
+              Faire le virement Interac à l'adresse courriel suivante{' '}
+              <strong>paiement.rpn@gmail.com</strong> et utiliser le mot de
+              passe <strong>monrpn</strong> si demandé. Ensuite, entrez ici les
+              informations du virement effectué pour renflouer votre compte RPN.
+              Le montant minimal est de <strong>{minAmount}$</strong>.
+            </span>
+          }
         >
           <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
               <FormField
                 control={form.control}
-                name='amountInterac'
+                name="amountInterac"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Montant Envoyé</FormLabel>
+                    <FormLabel>Montant envoyé</FormLabel>
                     <FormControl>
                       <Input
-                        type='text'
-                        placeholder='25'
+                        type="text"
+                        placeholder={minAmount.toString()}
                         value={ToLocaleStringFunc(field.value)}
                         onChange={(event) => {
                           const rawValue = event.target.value.replace(/\s/g, '')
@@ -156,48 +150,36 @@ Par la suite entrez les informations du virement que vous avez effectuer pour re
 
               <FormField
                 control={form.control}
-                name='refInterac'
+                name="refInterac"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel className='text-sm'>
+                    <FormLabel className="text-sm">
                       Numéro de référence du transfert Interac
                       <HoverCard>
-                        <HoverCardTrigger className='cursor-pointer'>
-                          (i)
+                        <HoverCardTrigger className="cursor-pointer italic text-xs hover:underline ml-1 animate-pulse">
+                          (où le trouver)
                         </HoverCardTrigger>
-                        <HoverCardContent className='font-light text-justify'>
-                          Interac vous envoie automatiquement un courriel de
-                          confirmation pour chaque virement réussi. Ce courriel
-                          contient votre &nbsp;
-                          <span className='text-destructive'>
-                            numéro de référence Interac
-                          </span>
-                          , qui commence généralement par CA. <br />
-                          Vous pouvez également trouver votre &nbsp;
-                          <span className='text-destructive'>
-                            numéro de référence Interac
-                          </span>
-                          &nbsp; sur votre confirmation de virement Interac ou
-                          sur la description de la transaction selon votre
-                          institution financière.
+                        <HoverCardContent className="font-light text-justify">
+                          Interac vous envoie un courriel de confirmation pour chaque virement.
+                          Ce courriel contient votre <span className="text-destructive">numéro de référence Interac</span>,
+                          qui commence généralement par CA. Vous pouvez aussi le retrouver sur la confirmation de virement
+                          ou dans la description de la transaction selon votre institution financière.
                         </HoverCardContent>
                       </HoverCard>
                     </FormLabel>
                     <FormControl>
-                      <Input placeholder='CAcM8D7L' {...field} />
+                      <Input placeholder="CAcM8D7L" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
               />
 
-              {isPending ? <Loading /> : <Button type='submit'>Valider</Button>}
+              {isPending ? <Loading /> : <Button type="submit">Valider</Button>}
             </form>
           </Form>
         </CustomModal>
-      ) : (
-        ''
-      )}
+      ) : null}
     </>
   )
 }

--- a/client/src/components/UserAccountInfo.tsx
+++ b/client/src/components/UserAccountInfo.tsx
@@ -61,7 +61,7 @@ const UserAccountInfo = () => {
         <CardContent>
           <div className='flex justify-between items-center'>
             <div
-              className={`text-3xl font-bold ${
+              className={`text-2xl font-bold ${
                 statusLabel ? 'text-gray-300 italic' : ''
               }`}
             >

--- a/client/src/hooks/accountHooks.ts
+++ b/client/src/hooks/accountHooks.ts
@@ -13,6 +13,7 @@ export const useGetAccountsByUserIdQuery = (userId?: string) =>
     queryKey: ['accountsByUserId', userId],
     queryFn: async () =>
       (await apiClient.get(`api/accounts/${userId}/all`)).data,
+    enabled: !!userId,
   })
 
 export const useGetAccountsQuery = () =>

--- a/client/src/hooks/useAwaitingFirstPaymentRedirect.ts
+++ b/client/src/hooks/useAwaitingFirstPaymentRedirect.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { Account } from '@/types/Account'
+import { toast } from '@/components/ui/use-toast'
+
+/**
+ * Redirects the user to the payment page if the account is awaiting its
+ * first payment.
+ * @param account Account associated with the current user
+ */
+const useAwaitingFirstPaymentRedirect = (account?: Account) => {
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  useEffect(() => {
+    if (
+      account?.isAwaitingFirstPayment &&
+      location.pathname !== '/payment-method'
+    ) {
+      toast({
+        variant: 'destructive',
+        title: 'Paiement requis',
+        description:
+          'Veuillez vous acquitter du montant minimum pour être membre. sinon des pénalités vous seront appliquées',
+      })
+      navigate('/payment-method')
+    }
+  }, [account?.isAwaitingFirstPayment, location.pathname, navigate])
+}
+
+export default useAwaitingFirstPaymentRedirect

--- a/client/src/pages/account/PaymentMethod.tsx
+++ b/client/src/pages/account/PaymentMethod.tsx
@@ -6,8 +6,21 @@ import { SearchEngineOptimization } from '@/components/SearchEngine/SearchEngine
 import { Store } from '@/lib/Store'
 import { useGetAccountsByUserIdQuery } from '@/hooks/accountHooks'
 import UpdateInteracPayment from '@/components/UpdateInteracPayment'
-import UpdateCreditCardPayment from '@/components/UpdateCreditCardPayment'
 import { useNavigate } from 'react-router-dom'
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { ShieldAlert } from 'lucide-react'
+
+const FirmNotice = () => (
+  <Alert variant="destructive" role="alert" className="mb-6 max-w-3xl mx-auto">
+    <ShieldAlert className="h-5 w-5" />
+    <AlertTitle>Action requise</AlertTitle>
+    <AlertDescription>
+      Le règlement du montant minimum requis pour votre profil est obligatoire pour conserver votre statut de membre.
+      En cas de <strong>non-paiement</strong> ou de <strong>déclaration inexacte</strong> du montant versé, des <strong>pénalités</strong> pourront être appliquées.
+    </AlertDescription>
+  </Alert>
+)
 
 const PaymentMethod = () => {
   const [totalPayment, setTotalPayment] = useState(0)
@@ -17,43 +30,37 @@ const PaymentMethod = () => {
   const { data: accounts } = useGetAccountsByUserIdQuery(userInfo?._id)
   const account = accounts?.[0]
 
-  const handleSuccess = () => {
+  const handleSuccess = async (amount: number) =>  {
+    console.log(`Payment successful: ${amount}`);
     navigate('/summary')
-  }
-
-  if (account?.isAwaitingFirstPayment) {
-    return (
-      <>
-        <SearchEngineOptimization title='Mode de paiement ACQ' description="Page de sélection du mode de paiement de l'association des camerounais du Québec ACQ" />
-        <div className='form flex-col sm:m-0 m-20' style={{ minHeight: '60vh', justifyContent: 'unset' }}>
-          <p className='text-center text-destructive mb-6'>
-            Veuillez vous acquitter du montant minimum pour être membre. sinon des pénalités vous seront appliquées
-          </p>
-          <div className='flex md:flex-row flex-col gap-8 text-center'>
-            {account.paymentMethod === 'interac' ? (
-              <UpdateInteracPayment onSuccess={handleSuccess} />
-            ) : (
-              <UpdateCreditCardPayment />
-            )}
-          </div>
-        </div>
-      </>
-    )
   }
 
   return (
     <>
-      <SearchEngineOptimization title='Mode de paiement ACQ' description="Page de sélection du mode de paiement de l'association des camerounais du Québec ACQ" />
+      <SearchEngineOptimization
+        title="Mode de paiement ACQ"
+        description="Page de sélection du mode de paiement de l'association des camerounais du Québec ACQ"
+      />
       <SelectFees updateTotal={setTotalPayment} />
 
-      <div className='form flex-col sm:m-0 m-20' id='payment-block' style={{ minHeight: '60vh', justifyContent: 'unset' }}>
-        <div className='text-center mt-8'>
-          <h1 className=' text-3xl font-bold'>Mode de paiement</h1>
+      <div className="form flex-col sm:m-0 m-20" id="payment-block" style={{ minHeight: '60vh', justifyContent: 'unset' }}>
+        <div className="text-center mt-8">
+          <h1 className="text-3xl font-bold">Mode de paiement</h1>
           <p>Choisissez par quel moyen vous souhaitez payer votre cotisation</p>
+          <p className="text-sm text-muted-foreground">
+            Les frais de service seront calculés et affichés avant la confirmation du paiement.
+          </p>
         </div>
-        <div className='flex md:flex-row flex-col gap-8 text-center'>
+
+        <FirmNotice />
+
+        <div className="flex md:flex-row flex-col gap-10 text-center">
           <CreditCardPayment />
-          <InteracPayment key={totalPayment} total={totalPayment} />
+          {account?.isAwaitingFirstPayment ? (
+             <UpdateInteracPayment minAmount={totalPayment} onSuccess={handleSuccess} />
+          ) : (
+             <InteracPayment key={totalPayment} total={totalPayment} />
+          )}
         </div>
       </div>
     </>

--- a/client/src/pages/account/PaymentMethod.tsx
+++ b/client/src/pages/account/PaymentMethod.tsx
@@ -30,8 +30,8 @@ const PaymentMethod = () => {
   const { data: accounts } = useGetAccountsByUserIdQuery(userInfo?._id)
   const account = accounts?.[0]
 
-  const handleSuccess = async (amount: number) =>  {
-    console.log(`Payment successful: ${amount}`);
+  const handleSuccess = () =>  {
+    console.log(`Payment successful: ${totalPayment}`);
     navigate('/summary')
   }
 

--- a/client/src/pages/account/PaymentMethod.tsx
+++ b/client/src/pages/account/PaymentMethod.tsx
@@ -1,11 +1,45 @@
 import CreditCardPayment from '@/components/CreditCardPayment'
 import InteracPayment from '@/components/InteracPayment'
 import SelectFees from './SelectFees'
-import { useState } from 'react'
+import { useContext, useState } from 'react'
 import { SearchEngineOptimization } from '@/components/SearchEngine/SearchEngineOptimization'
+import { Store } from '@/lib/Store'
+import { useGetAccountsByUserIdQuery } from '@/hooks/accountHooks'
+import UpdateInteracPayment from '@/components/UpdateInteracPayment'
+import UpdateCreditCardPayment from '@/components/UpdateCreditCardPayment'
+import { useNavigate } from 'react-router-dom'
 
 const PaymentMethod = () => {
   const [totalPayment, setTotalPayment] = useState(0)
+  const { state } = useContext(Store)
+  const { userInfo } = state
+  const navigate = useNavigate()
+  const { data: accounts } = useGetAccountsByUserIdQuery(userInfo?._id)
+  const account = accounts?.[0]
+
+  const handleSuccess = () => {
+    navigate('/summary')
+  }
+
+  if (account?.isAwaitingFirstPayment) {
+    return (
+      <>
+        <SearchEngineOptimization title='Mode de paiement ACQ' description="Page de sélection du mode de paiement de l'association des camerounais du Québec ACQ" />
+        <div className='form flex-col sm:m-0 m-20' style={{ minHeight: '60vh', justifyContent: 'unset' }}>
+          <p className='text-center text-destructive mb-6'>
+            Veuillez vous acquitter du montant minimum pour être membre. sinon des pénalités vous seront appliquées
+          </p>
+          <div className='flex md:flex-row flex-col gap-8 text-center'>
+            {account.paymentMethod === 'interac' ? (
+              <UpdateInteracPayment onSuccess={handleSuccess} />
+            ) : (
+              <UpdateCreditCardPayment />
+            )}
+          </div>
+        </div>
+      </>
+    )
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary
- redirect users awaiting first payment to the payment page
- guard routes by checking pending first payment on login
- load payment update flow instead of account creation when payment is pending

## Testing
- `cd client && npm test` *(fails: Unknown file extension ".png"; module resolution issues)*
- `cd server && npm test` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_e_68aeeefbab7483329091599b7a6f822f