### PR TITLE
feat: enforce first payment before accessing app

### DIFF
--- a/client/src/components/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute.tsx
@@ -1,14 +1,29 @@
 import { Store } from '@/lib/Store'
-import { useContext } from 'react'
+import { useContext, useEffect } from 'react'
 import { Navigate, Outlet } from 'react-router-dom'
 import Header from './Header'
 import Footer from './Footer'
 import Announcement from './Announcement'
+import { useGetAccountsByUserIdQuery } from '@/hooks/accountHooks'
+import useAwaitingFirstPaymentRedirect from '@/hooks/useAwaitingFirstPaymentRedirect'
 
 const ProtectedRoute = () => {
   const {
-    state: { userInfo },
+    state: { userInfo, accountInfo },
+    dispatch: ctxDispatch,
   } = useContext(Store)
+
+  const { data: accounts } = useGetAccountsByUserIdQuery(userInfo?._id)
+  const fetchedAccount = accounts?.[0]
+
+  useAwaitingFirstPaymentRedirect(accountInfo)
+
+  useEffect(() => {
+    if (fetchedAccount) {
+      ctxDispatch({ type: 'ACCOUNT_INFOS', payload: fetchedAccount })
+      localStorage.setItem('accountInfo', JSON.stringify(fetchedAccount))
+    }
+  }, [fetchedAccount, ctxDispatch])
 
   if (!userInfo) return <Navigate to='/login' />
   if (userInfo?.subscription?.status === 'inactive') {

--- a/client/src/hooks/accountHooks.ts
+++ b/client/src/hooks/accountHooks.ts
@@ -13,6 +13,7 @@ export const useGetAccountsByUserIdQuery = (userId?: string) =>
     queryKey: ['accountsByUserId', userId],
     queryFn: async () =>
       (await apiClient.get(`api/accounts/${userId}/all`)).data,
+    enabled: !!userId,
   })
 
 export const useGetAccountsQuery = () =>

--- a/client/src/hooks/useAwaitingFirstPaymentRedirect.ts
+++ b/client/src/hooks/useAwaitingFirstPaymentRedirect.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { Account } from '@/types/Account'
+import { toast } from '@/components/ui/use-toast'
+
+/**
+ * Redirects the user to the payment page if the account is awaiting its
+ * first payment.
+ * @param account Account associated with the current user
+ */
+const useAwaitingFirstPaymentRedirect = (account?: Account) => {
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  useEffect(() => {
+    if (
+      account?.isAwaitingFirstPayment &&
+      location.pathname !== '/payment-method'
+    ) {
+      toast({
+        variant: 'destructive',
+        title: 'Paiement requis',
+        description:
+          'Veuillez vous acquitter du montant minimum pour être membre. sinon des pénalités vous seront appliquées',
+      })
+      navigate('/payment-method')
+    }
+  }, [account?.isAwaitingFirstPayment, location.pathname, navigate])
+}
+
+export default useAwaitingFirstPaymentRedirect

--- a/client/src/lib/Store.tsx
+++ b/client/src/lib/Store.tsx
@@ -71,10 +71,10 @@ function userInfoReducer(state: User, action: Action) {
   }
 }
 
-function rootReducer(state: AppState, action: Action) {
+function rootReducer(state: AppState, action: Action): AppState {
   return {
     userInfo: userInfoReducer(state.userInfo!, action),
-    accountInfoReducer: accountInfoReducer(state.accountInfo!, action),
+    accountInfo: accountInfoReducer(state.accountInfo!, action),
   }
 }
 

--- a/client/src/pages/account/PaymentMethod.tsx
+++ b/client/src/pages/account/PaymentMethod.tsx
@@ -1,11 +1,45 @@
 import CreditCardPayment from '@/components/CreditCardPayment'
 import InteracPayment from '@/components/InteracPayment'
 import SelectFees from './SelectFees'
-import { useState } from 'react'
+import { useContext, useState } from 'react'
 import { SearchEngineOptimization } from '@/components/SearchEngine/SearchEngineOptimization'
+import { Store } from '@/lib/Store'
+import { useGetAccountsByUserIdQuery } from '@/hooks/accountHooks'
+import UpdateInteracPayment from '@/components/UpdateInteracPayment'
+import UpdateCreditCardPayment from '@/components/UpdateCreditCardPayment'
+import { useNavigate } from 'react-router-dom'
 
 const PaymentMethod = () => {
   const [totalPayment, setTotalPayment] = useState(0)
+  const { state } = useContext(Store)
+  const { userInfo } = state
+  const navigate = useNavigate()
+  const { data: accounts } = useGetAccountsByUserIdQuery(userInfo?._id)
+  const account = accounts?.[0]
+
+  const handleSuccess = () => {
+    navigate('/summary')
+  }
+
+  if (account?.isAwaitingFirstPayment) {
+    return (
+      <>
+        <SearchEngineOptimization title='Mode de paiement ACQ' description="Page de sélection du mode de paiement de l'association des camerounais du Québec ACQ" />
+        <div className='form flex-col sm:m-0 m-20' style={{ minHeight: '60vh', justifyContent: 'unset' }}>
+          <p className='text-center text-destructive mb-6'>
+            Veuillez vous acquitter du montant minimum pour être membre. sinon des pénalités vous seront appliquées
+          </p>
+          <div className='flex md:flex-row flex-col gap-8 text-center'>
+            {account.paymentMethod === 'interac' ? (
+              <UpdateInteracPayment onSuccess={handleSuccess} />
+            ) : (
+              <UpdateCreditCardPayment />
+            )}
+          </div>
+        </div>
+      </>
+    )
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary
- redirect users awaiting first payment to the payment page
- guard routes by checking pending first payment on login
- load payment update flow instead of account creation when payment is pending
- fix redirect loop after updating first payment by relying on account store
- correct store reducer to persist account information

## Testing
- `cd client && npm test` *(fails: Unknown file extension ".png")*
- `cd server && npm test` *(fails: ERR_REQUIRE_CYCLE_MODULE)*


------
https://chatgpt.com/codex/tasks/task_e_68aeeefbab7483329091599b7a6f822f