### PR TITLE
Exclude deleted users from queries

### DIFF
--- a/server/src/mailer/notification.ts
+++ b/server/src/mailer/notification.ts
@@ -12,7 +12,10 @@ export const notifyAllUsers = async ({
   deathPlace: string
   deathDate: Date
 }) => {
-  const users = await UserModel.find({ primaryMember: true })
+  const users = await UserModel.find({
+    primaryMember: true,
+    deletedAt: { $exists: false },
+  })
   const subject = emailContents.notificationDeces.sujet({ name: firstName })
   const text = emailContents.notificationDeces.texte({
     name: firstName,

--- a/server/src/routers/deathAnnoucementRouter.ts
+++ b/server/src/routers/deathAnnoucementRouter.ts
@@ -32,7 +32,10 @@ deathAnnouncementRouter.post(
         return
       }
       const amountPerPerson = settings.amountPerDependent
-      const users = await UserModel.find({ primaryMember: true }).lean()
+      const users = await UserModel.find({
+        primaryMember: true,
+        deletedAt: { $exists: false },
+      }).lean()
       const errors: any[] = []
 
       for (const user of users) {

--- a/server/src/routers/userRouter.ts
+++ b/server/src/routers/userRouter.ts
@@ -295,8 +295,10 @@ userRouter.get(
   isAdmin,
   expressAsyncHandler(async (req: Request, res: Response) => {
     try {
-      const users = await UserModel.find()
-      const countUsers = await UserModel.countDocuments()
+      const users = await UserModel.find({ deletedAt: { $exists: false } })
+      const countUsers = await UserModel.countDocuments({
+        deletedAt: { $exists: false },
+      })
       res.send({
         users,
         countUsers,
@@ -350,6 +352,7 @@ userRouter.get(
     try {
       const users = await UserModel.find({
         referredBy: req.params.referredBy,
+        deletedAt: { $exists: false },
       })
         .populate('referredBy', '_id origines.firstName origines.lastName')
         .sort({ createdAt: -1 })

--- a/server/src/services/checkMinimumBalanceAndSendReminder.ts
+++ b/server/src/services/checkMinimumBalanceAndSendReminder.ts
@@ -13,7 +13,7 @@ export const checkMinimumBalanceAndSendReminder = async () => {
   const MINIMUM_UNIT = settings?.minimumBalanceRPN || 50
   const MAX_MISSED = settings?.maxMissedReminders || 3
 
-  const users = await UserModel.find()
+  const users = await UserModel.find({ deletedAt: { $exists: false } })
   for (const user of users) {
     const totalPersons = calculateTotalPersons(user)
 

--- a/server/src/services/membershipService.ts
+++ b/server/src/services/membershipService.ts
@@ -41,7 +41,7 @@ const calculateMembershipAmount = (
 }
 
 export const processAnnualMembershipPayment = async () => {
-  const users = await UserModel.find()
+  const users = await UserModel.find({ deletedAt: { $exists: false } })
   const settings = await SettingsModel.findOne()
   const MEMBERSHIP_WORKER_AMOUNT = settings?.membershipUnitAmount || 50
   const MEMBERSHIP_STUDENT_AMOUNT = 25
@@ -212,6 +212,7 @@ export const processInactiveUsers = async () => {
     'subscription.scheduledDeactivationDate': {
       $lte: today,
     },
+    deletedAt: { $exists: false },
   })
 
   for (const user of usersToDeactivate) {


### PR DESCRIPTION
## Summary
- skip soft-deleted users when processing membership payments or deactivations
- ignore deleted users in balance checks, notifications, and death announcements
- return only active users in admin and referral listings

## Testing
- `cd server && npm test` *(fails: Error [ERR_REQUIRE_CYCLE_MODULE])*

------
https://chatgpt.com/codex/tasks/task_e_68b1086c141c83328ecab5cf7186372b