### PR TITLE
refactor: introduce transaction state pattern

### DIFF
--- a/client/src/components/LastUserTransactions.tsx
+++ b/client/src/components/LastUserTransactions.tsx
@@ -67,24 +67,8 @@ const LastUserTransactions = () => {
                     {formatCurrency(tx.amount)}
                   </TableCell>
                   <TableCell>
-                    <Badge
-                      className={`text-xs ${
-                        tx.status === 'completed'
-                          ? 'bg-green-500'
-                          : tx.status === 'pending'
-                          ? 'bg-yellow-500'
-                          : tx.status === 'awaiting_payment'
-                          ? 'bg-blue-500'
-                          : 'bg-red-500'
-                      }`}
-                    >
-                      {tx.status === 'completed'
-                        ? 'Réussie'
-                        : tx.status === 'pending'
-                        ? 'En approbation'
-                        : tx.status === 'awaiting_payment'
-                        ? 'En attente paiement'
-                        : 'Échouée'}
+                    <Badge className={tx.state.applyStyle()}>
+                      {tx.state.getLabel()}
                     </Badge>
                   </TableCell>
                 </TableRow>

--- a/client/src/components/UserAccountInfo.tsx
+++ b/client/src/components/UserAccountInfo.tsx
@@ -28,7 +28,10 @@ const UserAccountInfo = () => {
   
   const lastTransaction =
     transactions && transactions.length > 0 ? transactions[0] : undefined
-  const statusLabel = getAccountStatusLabel(account?.[0], lastTransaction?.status)
+  const statusLabel = getAccountStatusLabel(
+    account?.[0],
+    lastTransaction?.state.status,
+  )
 
   const handleTransactionSuccess = async (amount: number) => {
     setCurrentSolde((prevSolde) =>

--- a/client/src/domain/transaction/TransactionState.ts
+++ b/client/src/domain/transaction/TransactionState.ts
@@ -1,0 +1,5 @@
+export interface TransactionState {
+  status: string
+  getLabel(): string
+  applyStyle(): string
+}

--- a/client/src/domain/transaction/states/AwaitingPaymentState.ts
+++ b/client/src/domain/transaction/states/AwaitingPaymentState.ts
@@ -1,0 +1,11 @@
+import { TransactionState } from '../TransactionState'
+
+export class AwaitingPaymentState implements TransactionState {
+  status = 'awaiting_payment'
+  getLabel(): string {
+    return 'En attente paiement'
+  }
+  applyStyle(): string {
+    return 'bg-blue-500 text-white text-xs'
+  }
+}

--- a/client/src/domain/transaction/states/CompletedState.ts
+++ b/client/src/domain/transaction/states/CompletedState.ts
@@ -1,0 +1,11 @@
+import { TransactionState } from '../TransactionState'
+
+export class CompletedState implements TransactionState {
+  status = 'completed'
+  getLabel(): string {
+    return 'Réussie'
+  }
+  applyStyle(): string {
+    return 'bg-green-500 text-white text-xs'
+  }
+}

--- a/client/src/domain/transaction/states/FailedState.ts
+++ b/client/src/domain/transaction/states/FailedState.ts
@@ -1,0 +1,11 @@
+import { TransactionState } from '../TransactionState'
+
+export class FailedState implements TransactionState {
+  status = 'failed'
+  getLabel(): string {
+    return 'Echouée'
+  }
+  applyStyle(): string {
+    return 'bg-red-500 text-white text-xs'
+  }
+}

--- a/client/src/domain/transaction/states/PendingState.ts
+++ b/client/src/domain/transaction/states/PendingState.ts
@@ -1,0 +1,11 @@
+import { TransactionState } from '../TransactionState'
+
+export class PendingState implements TransactionState {
+  status = 'pending'
+  getLabel(): string {
+    return 'En approbation'
+  }
+  applyStyle(): string {
+    return 'bg-yellow-500 text-white text-xs'
+  }
+}

--- a/client/src/domain/transaction/states/index.ts
+++ b/client/src/domain/transaction/states/index.ts
@@ -1,0 +1,25 @@
+export { CompletedState } from './CompletedState'
+export { FailedState } from './FailedState'
+export { PendingState } from './PendingState'
+export { AwaitingPaymentState } from './AwaitingPaymentState'
+
+import { TransactionState } from '../TransactionState'
+import { CompletedState } from './CompletedState'
+import { FailedState } from './FailedState'
+import { PendingState } from './PendingState'
+import { AwaitingPaymentState } from './AwaitingPaymentState'
+
+export const createTransactionState = (status: string): TransactionState => {
+  switch (status) {
+    case 'completed':
+      return new CompletedState()
+    case 'failed':
+      return new FailedState()
+    case 'pending':
+      return new PendingState()
+    case 'awaiting_payment':
+      return new AwaitingPaymentState()
+    default:
+      return new PendingState()
+  }
+}

--- a/client/src/hooks/transactionHooks.ts
+++ b/client/src/hooks/transactionHooks.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery } from '@tanstack/react-query'
 import apiClient from '@/apiClient'
 import { Transaction } from '@/types/Transaction'
+import { createTransactionState } from '@/domain/transaction/states'
 
 export const useNewTransactionMutation = () =>
   useMutation({
@@ -34,8 +35,13 @@ export const useSendManualRemindersMutation = () =>
 export const useGetAllTransactionsQuery = () =>
   useQuery({
     queryKey: ['transactions'],
-    queryFn: async () =>
-      (await apiClient.get<Transaction[]>(`api/transactions/all`)).data,
+    queryFn: async () => {
+      const data = (await apiClient.get<any[]>(`api/transactions/all`)).data
+      return data.map((tx) => ({
+        ...tx,
+        state: createTransactionState(tx.state?.status ?? tx.state),
+      })) as Transaction[]
+    },
   })
 
 export const useGetTransactionSummaryQuery = () =>
@@ -47,9 +53,15 @@ export const useGetTransactionSummaryQuery = () =>
 export const useGetTransactionsByUserIdQuery = (userId?: string) =>
   useQuery({
     queryKey: ['transactions', userId],
-    queryFn: async () =>
-      (await apiClient.get<Transaction[]>(`api/transactions/${userId}/all`))
-        .data,
+    queryFn: async () => {
+      const data = (
+        await apiClient.get<any[]>(`api/transactions/${userId}/all`)
+      ).data
+      return data.map((tx) => ({
+        ...tx,
+        state: createTransactionState(tx.state?.status ?? tx.state),
+      })) as Transaction[]
+    },
     enabled: !!userId,
   })
 

--- a/client/src/lib/accountUtils.ts
+++ b/client/src/lib/accountUtils.ts
@@ -8,7 +8,7 @@ export const getAccountDisplayStatus = (
 ) => {
   const awaitingPayment = Boolean(account?.isAwaitingFirstPayment)
   const lastTransactionPending =
-    !awaitingPayment && lastTransaction?.status === 'pending'
+    !awaitingPayment && lastTransaction?.state.status === 'pending'
 
   return { awaitingPayment, lastTransactionPending }
 }

--- a/client/src/pages/transactions/Transactions.tsx
+++ b/client/src/pages/transactions/Transactions.tsx
@@ -13,6 +13,7 @@ import { Transaction } from '@/types/Transaction'
 import { ColumnDef } from '@tanstack/react-table'
 import { ArrowUpDown } from 'lucide-react'
 import { useContext } from 'react'
+import { TransactionState } from '@/domain/transaction/TransactionState'
 
 const TransactionsByUserId = () => {
   const { state } = useContext(Store)
@@ -63,19 +64,11 @@ const TransactionsByUserId = () => {
       },
     },
     {
-      accessorKey: 'status',
+      accessorKey: 'state',
       header: 'Statut',
       cell: ({ row }) => {
-        const status: string = row.getValue('status')
-        return (
-          <Badge
-            className={`text-xs ${
-              status === 'completed' ? 'bg-green-500' : 'bg-red-500'
-            }`}
-          >
-            {status === 'completed' ? 'Réussie' : 'Échouée'}
-          </Badge>
-        )
+        const state = row.getValue('state') as TransactionState
+        return <Badge className={state.applyStyle()}>{state.getLabel()}</Badge>
       },
     },
   ]

--- a/client/src/types/Transaction.ts
+++ b/client/src/types/Transaction.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { TransactionState } from '@/domain/transaction/TransactionState'
+
 export type Transaction = {
   _id?: string
   userId: string | any
@@ -6,6 +8,6 @@ export type Transaction = {
   type: 'debit' | 'credit'
   reason: string
   refInterac?: string
-  status: 'completed' | 'failed' | 'pending' | 'awaiting_payment'
+  state: TransactionState
   createdAt?: Date
 }

--- a/client/test/accountUtils.test.js
+++ b/client/test/accountUtils.test.js
@@ -4,7 +4,7 @@ import { getAccountDisplayStatus } from '../src/lib/accountUtils.ts'
 test('detects awaiting first payment', () => {
   const { awaitingPayment, lastTransactionPending } = getAccountDisplayStatus(
     { isAwaitingFirstPayment: true },
-    { status: 'awaiting_payment' }
+    { state: { status: 'awaiting_payment' } }
   )
   equal(awaitingPayment, true)
   equal(lastTransactionPending, false)
@@ -13,7 +13,7 @@ test('detects awaiting first payment', () => {
 test('detects pending transaction', () => {
   const { awaitingPayment, lastTransactionPending } = getAccountDisplayStatus(
     { isAwaitingFirstPayment: false },
-    { status: 'pending' }
+    { state: { status: 'pending' } }
   )
   equal(awaitingPayment, false)
   equal(lastTransactionPending, true)

--- a/server/src/domain/transaction/TransactionState.ts
+++ b/server/src/domain/transaction/TransactionState.ts
@@ -1,0 +1,5 @@
+export interface TransactionState {
+  status: string
+  getLabel(): string
+  applyStyle(): string
+}

--- a/server/src/domain/transaction/states/AwaitingPaymentState.ts
+++ b/server/src/domain/transaction/states/AwaitingPaymentState.ts
@@ -1,0 +1,11 @@
+import { TransactionState } from '../TransactionState'
+
+export class AwaitingPaymentState implements TransactionState {
+  status = 'awaiting_payment'
+  getLabel(): string {
+    return 'En attente paiement'
+  }
+  applyStyle(): string {
+    return 'bg-blue-500 text-white text-xs'
+  }
+}

--- a/server/src/domain/transaction/states/CompletedState.ts
+++ b/server/src/domain/transaction/states/CompletedState.ts
@@ -1,0 +1,11 @@
+import { TransactionState } from '../TransactionState'
+
+export class CompletedState implements TransactionState {
+  status = 'completed'
+  getLabel(): string {
+    return 'Réussie'
+  }
+  applyStyle(): string {
+    return 'bg-green-500 text-white text-xs'
+  }
+}

--- a/server/src/domain/transaction/states/FailedState.ts
+++ b/server/src/domain/transaction/states/FailedState.ts
@@ -1,0 +1,11 @@
+import { TransactionState } from '../TransactionState'
+
+export class FailedState implements TransactionState {
+  status = 'failed'
+  getLabel(): string {
+    return 'Echouée'
+  }
+  applyStyle(): string {
+    return 'bg-red-500 text-white text-xs'
+  }
+}

--- a/server/src/domain/transaction/states/PendingState.ts
+++ b/server/src/domain/transaction/states/PendingState.ts
@@ -1,0 +1,11 @@
+import { TransactionState } from '../TransactionState'
+
+export class PendingState implements TransactionState {
+  status = 'pending'
+  getLabel(): string {
+    return 'En approbation'
+  }
+  applyStyle(): string {
+    return 'bg-yellow-500 text-white text-xs'
+  }
+}

--- a/server/src/domain/transaction/states/index.ts
+++ b/server/src/domain/transaction/states/index.ts
@@ -1,0 +1,25 @@
+export { CompletedState } from './CompletedState'
+export { FailedState } from './FailedState'
+export { PendingState } from './PendingState'
+export { AwaitingPaymentState } from './AwaitingPaymentState'
+
+import { TransactionState } from '../TransactionState'
+import { CompletedState } from './CompletedState'
+import { FailedState } from './FailedState'
+import { PendingState } from './PendingState'
+import { AwaitingPaymentState } from './AwaitingPaymentState'
+
+export const createTransactionState = (status: string): TransactionState => {
+  switch (status) {
+    case 'completed':
+      return new CompletedState()
+    case 'failed':
+      return new FailedState()
+    case 'pending':
+      return new PendingState()
+    case 'awaiting_payment':
+      return new AwaitingPaymentState()
+    default:
+      return new PendingState()
+  }
+}

--- a/server/src/models/transactionModel.ts
+++ b/server/src/models/transactionModel.ts
@@ -2,6 +2,8 @@
 
 import { prop, getModelForClass, modelOptions, Ref } from '@typegoose/typegoose'
 import { User } from './userModel'
+import { TransactionState } from '../domain/transaction/TransactionState'
+import { CompletedState } from '../domain/transaction/states'
 
 @modelOptions({
   schemaOptions: { timestamps: true },
@@ -24,8 +26,8 @@ export class Transaction {
   @prop()
   public refInterac?: string
 
-  @prop({ required: true, default: 'completed' })
-  public status!: 'completed' | 'failed' | 'pending' | 'awaiting_payment'
+  @prop({ type: () => Object, required: true, default: () => new CompletedState() })
+  public state!: TransactionState
 }
 
 export const TransactionModel = getModelForClass(Transaction)

--- a/server/src/routers/transactionRouter.ts
+++ b/server/src/routers/transactionRouter.ts
@@ -83,7 +83,7 @@ transactionRouter.get(
       const statusSummary = await TransactionModel.aggregate([
         {
           $group: {
-            _id: '$status',
+            _id: '$state.status',
             count: { $sum: 1 },
           },
         },
@@ -121,7 +121,7 @@ transactionRouter.delete(
   //isAdmin,
   expressAsyncHandler(async (req: Request, res: Response) => {
     try {
-      const result = await TransactionModel.deleteMany({ status: undefined })
+      const result = await TransactionModel.deleteMany({ state: undefined })
 
       res.send({
         message: labels.transaction.supprimeSucces,

--- a/server/src/services/membershipService.ts
+++ b/server/src/services/membershipService.ts
@@ -1,5 +1,9 @@
 import { UserModel, User } from '../models/userModel'
 import { TransactionModel } from '../models/transactionModel'
+import {
+  CompletedState,
+  FailedState,
+} from '../domain/transaction/states'
 import { AccountModel } from '../models/accountModel'
 import { SettingsModel } from '../models/settingsModel'
 import { calculateTotalPersons } from '../utils'
@@ -80,7 +84,7 @@ export const processAnnualMembershipPayment = async () => {
         amount: totalToDeduct,
         reason: 'Cotisation annuelle',
         type: 'debit',
-        status: 'completed',
+        state: new CompletedState(),
       })
 
       await sendMembershipSuccessEmail(
@@ -106,7 +110,7 @@ export const processAnnualMembershipPayment = async () => {
         amount: totalToDeduct,
         reason: 'Cotisation annuelle',
         type: 'debit',
-        status: 'failed',
+        state: new FailedState(),
       })
 
       await handleFailedPrelevement({
@@ -159,7 +163,7 @@ export const processMembershipForUser = async (userId: string) => {
       amount: totalToDeduct,
       reason: 'Cotisation annuelle',
       type: 'debit',
-      status: 'completed',
+      state: new CompletedState(),
     })
 
     user!.subscription.lastMembershipPaymentYear = currentYear
@@ -185,7 +189,7 @@ export const processMembershipForUser = async (userId: string) => {
       amount: totalToDeduct,
       reason: 'Cotisation annuelle',
       type: 'debit',
-      status: 'failed',
+      state: new FailedState(),
     })
 
     await handleFailedPrelevement({

--- a/server/src/services/subscriptionService.ts
+++ b/server/src/services/subscriptionService.ts
@@ -3,6 +3,7 @@ import {
   sendPrelevementFailedEmail,
 } from '../mailer'
 import { TransactionModel } from '../models/transactionModel'
+import { FailedState } from '../domain/transaction/states'
 import { User } from '../models/userModel'
 import { DocumentType } from '@typegoose/typegoose'
 
@@ -30,7 +31,7 @@ export const handleFailedPrelevement = async ({
         ? 'Cotisation annuelle'
         : `Prélèvement décès pour ${totalPersons} personnes`,
     type: 'debit',
-    status: 'failed',
+    state: new FailedState(),
   })
 
   //Compteur de rappels


### PR DESCRIPTION
## Summary
- add TransactionState interface and concrete state classes
- wire transactions to hold state objects instead of raw status strings
- refactor UI and services to leverage state methods

## Testing
- `npm test` *(fails: ERR_REQUIRE_CYCLE_MODULE)*
- `npm test` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*

------
https://chatgpt.com/codex/tasks/task_e_68c0caef796883328dd215d23b2a02e4