### PR TITLE
refactor subscription status to state pattern

### DIFF
--- a/client/src/components/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute.tsx
@@ -6,6 +6,7 @@ import Footer from './Footer'
 import Announcement from './Announcement'
 import { useGetAccountsByUserIdQuery } from '@/hooks/accountHooks'
 import useAwaitingFirstPaymentRedirect from '@/hooks/useAwaitingFirstPaymentRedirect'
+import { SubscriptionState } from '../../../src/domain/subscription/SubscriptionState'
 
 const ProtectedRoute = () => {
   const {
@@ -26,7 +27,8 @@ const ProtectedRoute = () => {
   }, [fetchedAccount, ctxDispatch])
 
   if (!userInfo) return <Navigate to='/login' />
-  if (userInfo?.subscription?.status === 'inactive') {
+  const state = userInfo?.subscription?.state as SubscriptionState | undefined
+  if (state && !state.canAccess()) {
     return <Navigate to='/account-deactivated' />
   }
 

--- a/client/src/pages/admin/accounts/Accounts.tsx
+++ b/client/src/pages/admin/accounts/Accounts.tsx
@@ -40,6 +40,8 @@ import { ArrowUpDown, Pencil } from 'lucide-react'
 import { useContext, useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { SubscriptionState } from '../../../../../src/domain/subscription/SubscriptionState'
+import { InactiveState } from '../../../../../src/domain/subscription/states/InactiveState'
 
 const formSchema = z.object({
   firstName: z.string(),
@@ -101,9 +103,10 @@ const Accounts = () => {
       header: 'Créé le',
       cell: ({ row }) => {
         const created: string = row.getValue('createdAt')
-        const status = row.original.userId.subscription.status
+        const state =
+          row.original.userId.subscription.state as SubscriptionState
         return (
-          <div className={status === 'inactive' ? 'text-gray-400' : ''}>
+          <div className={!state.canAccess() ? 'text-gray-400' : ''}>
             {' '}
             {functionReverse(created.substring(0, 10))}{' '}
           </div>
@@ -125,9 +128,10 @@ const Accounts = () => {
       },
       accessorFn: (row) => `${row.firstName} ${row.lastName}`, // Génère dynamiquement le champ
       cell: ({ row }) => {
-        const status = row.original.userId.subscription.status
+        const state =
+          row.original.userId.subscription.state as SubscriptionState
         return (
-          <div className={status === 'inactive' ? 'text-gray-400' : ''}>
+          <div className={!state.canAccess() ? 'text-gray-400' : ''}>
             {row.original.firstName} {row.original.lastName}
           </div>
         )
@@ -152,11 +156,11 @@ const Accounts = () => {
         )
       },
       cell: ({ row }) => {
-        const isInactive =
-          row.original.userId.subscription.status === 'inactive'
+        const state =
+          row.original.userId.subscription.state as SubscriptionState
         const userTel: string = row.getValue('userTel')
         return (
-          <div className={isInactive ? 'text-gray-400' : ''}>{userTel}</div>
+          <div className={!state.canAccess() ? 'text-gray-400' : ''}>{userTel}</div>
         )
       },
     },
@@ -174,11 +178,11 @@ const Accounts = () => {
         )
       },
       cell: ({ row }) => {
-        const isInactive =
-          row.original.userId.subscription.status === 'inactive'
+        const state =
+          row.original.userId.subscription.state as SubscriptionState
         const residenceCountry: string = row.getValue('userResidenceCountry')
         return (
-          <div className={isInactive ? 'text-gray-400' : ''}>
+          <div className={!state.canAccess() ? 'text-gray-400' : ''}>
             {residenceCountry}
           </div>
         )
@@ -189,9 +193,10 @@ const Accounts = () => {
       header: 'Solde',
       cell: ({ row }) => {
         const solde: number = row.getValue('solde')
-        const status = row.original.userId.subscription.status
+        const state =
+          row.original.userId.subscription.state as SubscriptionState
         return (
-          <div className={status === 'inactive' ? 'text-gray-400' : ''}>
+          <div className={!state.canAccess() ? 'text-gray-400' : ''}>
             {' '}
             {ToLocaleStringFunc(solde)}{' '}
           </div>
@@ -203,9 +208,10 @@ const Accounts = () => {
       header: 'En attente paiement',
       cell: ({ row }) => {
         const awaiting: boolean = row.getValue('isAwaitingFirstPayment')
-        const status = row.original.userId.subscription.status
+        const state =
+          row.original.userId.subscription.state as SubscriptionState
         return (
-          <div className={status === 'inactive' ? 'text-gray-400' : ''}>
+          <div className={!state.canAccess() ? 'text-gray-400' : ''}>
             {awaiting ? 'Oui' : 'Non'}
           </div>
         )
@@ -216,12 +222,13 @@ const Accounts = () => {
       header: 'Méthode paiement',
       cell: ({ row }) => {
         const paymentMethod = row.original.paymentMethod
-        const status = row.original.userId.subscription.status
+        const state =
+          row.original.userId.subscription.state as SubscriptionState
         if (paymentMethod === 'credit_card') {
           return (
             <Badge
               className={
-                status === 'inactive' ? 'bg-gray-400' : 'bg-fuchsia-500'
+                !state.canAccess() ? 'bg-gray-400' : 'bg-fuchsia-500'
               }
             >
               {paymentMethod}
@@ -230,7 +237,7 @@ const Accounts = () => {
         } else {
           return (
             <Badge
-              className={status === 'inactive' ? 'bg-gray-400' : 'bg-sky-400'}
+              className={!state.canAccess() ? 'bg-gray-400' : 'bg-sky-400'}
             >
               {paymentMethod}
             </Badge>
@@ -243,8 +250,9 @@ const Accounts = () => {
       header: () => <div className="text-center w-full">Action</div>,
       enableHiding: false,
       cell: ({ row }) => {
-        const isInactive =
-          row.original.userId.subscription.status === 'inactive'
+        const state =
+          row.original.userId.subscription.state as SubscriptionState
+        const isInactive = state instanceof InactiveState
         return (
           <div className={`flex `}>
             <IconButtonWithTooltip
@@ -273,7 +281,7 @@ const Accounts = () => {
               refetch={refetch}
             />
             <div className='font-semibold text-[#b9bdbc] mx-2'>|</div>
-            {row.original.userId.subscription.status === 'inactive' ? (
+            {isInactive ? (
               <ManualReactivateButton
                 userId={row.original.userId._id}
                 refetch={refetch}

--- a/client/src/types/User.ts
+++ b/client/src/types/User.ts
@@ -1,3 +1,5 @@
+import { SubscriptionState } from '../../../src/domain/subscription/SubscriptionState'
+
 export type Register = {
   email: string
   password: string
@@ -50,7 +52,7 @@ export type FamilyMember = {
 
 export type Subscription = {
   startDate: Date
-  status: string
+  state: SubscriptionState
 }
 
 export type User = {

--- a/server/src/models/userModel.ts
+++ b/server/src/models/userModel.ts
@@ -5,6 +5,8 @@ import {
   Ref,
   Severity,
 } from '@typegoose/typegoose'
+import { SubscriptionState } from '../../../src/domain/subscription/SubscriptionState'
+import { RegisteredState } from '../../../src/domain/subscription/states/RegisteredState'
 
 class Infos {
   @prop({ required: true })
@@ -133,12 +135,8 @@ class Subscription {
   @prop({ required: true, default: Date.now })
   public startDate!: Date
 
-  @prop({
-    required: true,
-    default: 'registered',
-    enum: ['registered', 'active', 'inactive', 'expired'],
-  })
-  public status!: 'registered' | 'active' | 'inactive' | 'expired'
+  @prop({ required: true, default: () => new RegisteredState() })
+  public state!: SubscriptionState
 
   @prop({ default: undefined })
   public endDate?: Date

--- a/server/src/routers/accountRouter.ts
+++ b/server/src/routers/accountRouter.ts
@@ -28,7 +28,7 @@ accountRouter.get(
     try {
       const accounts = await AccountModel.find().populate(
         'userId',
-        '_id isAdmin subscription.status deletedAt'
+        '_id isAdmin subscription.state deletedAt'
       )
       const activeAccounts = accounts.filter(
         (account) => !(account as any).userId?.deletedAt
@@ -49,7 +49,7 @@ accountRouter.get(
       const accountsByUserId = await AccountModel.find({
         userId: req.params.userId,
       })
-        .populate('userId', '_id infos origines subscription.status')
+        .populate('userId', '_id infos origines subscription.state')
         .exec()
       res.send(accountsByUserId)
     } catch (error) {

--- a/server/src/services/subscriptionService.ts
+++ b/server/src/services/subscriptionService.ts
@@ -21,6 +21,9 @@ export const handleFailedPrelevement = async ({
   maxMissed: number
   totalPersons: number
 }) => {
+  if (!user.subscription.state.canAccess()) {
+    return
+  }
   // Transaction échouée
   await TransactionModel.create({
     userId: user._id,

--- a/src/domain/subscription/SubscriptionState.ts
+++ b/src/domain/subscription/SubscriptionState.ts
@@ -1,0 +1,21 @@
+export interface SubscriptionState {
+  /**
+   * Determines if the subscription state allows user access.
+   */
+  canAccess(): boolean
+
+  /**
+   * Handles a successful payment and returns the next state.
+   */
+  onPayment(): SubscriptionState
+
+  /**
+   * Transition to an inactive state.
+   */
+  deactivate(): SubscriptionState
+
+  /**
+   * Reactivate the subscription.
+   */
+  reactivate(): SubscriptionState
+}

--- a/src/domain/subscription/states/ActiveState.ts
+++ b/src/domain/subscription/states/ActiveState.ts
@@ -1,0 +1,20 @@
+import { SubscriptionState } from '../SubscriptionState'
+import { InactiveState } from './InactiveState'
+
+export class ActiveState implements SubscriptionState {
+  canAccess(): boolean {
+    return true
+  }
+
+  onPayment(): SubscriptionState {
+    return this
+  }
+
+  deactivate(): SubscriptionState {
+    return new InactiveState()
+  }
+
+  reactivate(): SubscriptionState {
+    return this
+  }
+}

--- a/src/domain/subscription/states/ExpiredState.ts
+++ b/src/domain/subscription/states/ExpiredState.ts
@@ -1,0 +1,20 @@
+import { SubscriptionState } from '../SubscriptionState'
+import { ActiveState } from './ActiveState'
+
+export class ExpiredState implements SubscriptionState {
+  canAccess(): boolean {
+    return false
+  }
+
+  onPayment(): SubscriptionState {
+    return new ActiveState()
+  }
+
+  deactivate(): SubscriptionState {
+    return this
+  }
+
+  reactivate(): SubscriptionState {
+    return new ActiveState()
+  }
+}

--- a/src/domain/subscription/states/InactiveState.ts
+++ b/src/domain/subscription/states/InactiveState.ts
@@ -1,0 +1,20 @@
+import { SubscriptionState } from '../SubscriptionState'
+import { ActiveState } from './ActiveState'
+
+export class InactiveState implements SubscriptionState {
+  canAccess(): boolean {
+    return false
+  }
+
+  onPayment(): SubscriptionState {
+    return new ActiveState()
+  }
+
+  deactivate(): SubscriptionState {
+    return this
+  }
+
+  reactivate(): SubscriptionState {
+    return new ActiveState()
+  }
+}

--- a/src/domain/subscription/states/RegisteredState.ts
+++ b/src/domain/subscription/states/RegisteredState.ts
@@ -1,0 +1,21 @@
+import { SubscriptionState } from '../SubscriptionState'
+import { ActiveState } from './ActiveState'
+import { InactiveState } from './InactiveState'
+
+export class RegisteredState implements SubscriptionState {
+  canAccess(): boolean {
+    return true
+  }
+
+  onPayment(): SubscriptionState {
+    return new ActiveState()
+  }
+
+  deactivate(): SubscriptionState {
+    return new InactiveState()
+  }
+
+  reactivate(): SubscriptionState {
+    return new ActiveState()
+  }
+}


### PR DESCRIPTION
## Summary
- introduce subscription state interface and concrete states
- refactor server models and services to use state objects
- update client components to depend on subscription state methods

## Testing
- `npm test` (server) *(fails: ERR_TEST_FAILURE)*
- `npm test` (client) *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_68c0caf75ed48332a97b5aeae4c56df6