### PR TITLE
refactor: introduce family member state pattern

### DIFF
--- a/client/src/components/AddMemberSection.tsx
+++ b/client/src/components/AddMemberSection.tsx
@@ -36,6 +36,7 @@ import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
 import { format } from 'date-fns'
 import { CalendarIcon } from 'lucide-react'
 import { Calendar } from './CustomCalendar'
+import { stateFromName } from '../../../src/domain/familyMember/states'
 
 const formSchema = z.object({
   firstName: z.string(),
@@ -98,9 +99,13 @@ const AddMemberSection = () => {
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     try {
+      const { status: memberStatus, ...rest } = values
       await updateUser({
         ...user!,
-        familyMembers: [...(user?.familyMembers ?? []), values],
+        familyMembers: [
+          ...(user?.familyMembers ?? []),
+          { ...rest, state: stateFromName(memberStatus as any) },
+        ],
         _id: user?._id,
       })
       if (pathname === '/dependents') {

--- a/client/src/pages/profil/Dependents.tsx
+++ b/client/src/pages/profil/Dependents.tsx
@@ -53,6 +53,7 @@ import { cn, toastAxiosError } from '@/lib/utils'
 import { format } from 'date-fns'
 import { Calendar } from '@/components/CustomCalendar'
 import IconButtonWithTooltip from '@/components/IconButtonWithTooltip'
+import { stateFromName } from '../../../../src/domain/familyMember/states'
 
 const formSchema = z.object({
   firstName: z.string(),
@@ -102,7 +103,7 @@ const Dependents = () => {
       residenceCountryStatus: editingItem
         ? editingItem.residenceCountryStatus
         : 'worker',
-      status: editingItem ? editingItem.status : '',
+      status: editingItem ? editingItem.state.name : '',
       birthDate: editingItem ? editingItem.birthDate : new Date('1990-01-01'),
       tel: editingItem ? editingItem.tel : '',
     },
@@ -114,7 +115,7 @@ const Dependents = () => {
         firstName: editingItem.firstName || '',
         lastName: editingItem.lastName || '',
         relationship: editingItem.relationship || '',
-        status: editingItem.status || '',
+        status: editingItem.state.name || '',
         residenceCountryStatus: editingItem.residenceCountryStatus || 'worker',
         birthDate: new Date(editingItem.birthDate),
         tel: editingItem.tel,
@@ -189,27 +190,15 @@ const Dependents = () => {
       header: 'Téléphone',
     },
     {
-      accessorKey: 'status',
+      accessorKey: 'state',
       header: 'Statut',
       cell: ({ row }) => {
-        const status = row.original.status
-        if (status === 'active') {
-          return <Badge className='font-normal'>Actif</Badge>
-        }
-        if (status === 'inactive') {
-          return (
-            <Badge className='font-normal' variant='outline'>
-              Inactif
-            </Badge>
-          )
-        }
-        if (status === 'deleted') {
-          return (
-            <Badge className='font-normal' variant='destructive'>
-              Supprimé
-            </Badge>
-          )
-        }
+        const { label, variant } = row.original.state.badgeProps()
+        return (
+          <Badge className='font-normal' variant={variant}>
+            {label}
+          </Badge>
+        )
       },
     },
     {
@@ -226,7 +215,7 @@ const Dependents = () => {
               setModalVisibility(true)
               setGetIndex(row.index)
             }}
-            disabled={row.original.status === 'deleted' ? true : false}
+            disabled={!row.original.state.isEditable()}
           />
 
           <div className='font-semibold text-[#b9bdbc] mx-4'>
@@ -241,7 +230,7 @@ const Dependents = () => {
               setDeleteModal(true)
               setGetIndex(row.index)
             }}
-            disabled={row.original.status === 'deleted' ? true : false}
+            disabled={!row.original.state.isEditable()}
           />
         </div>
       ),
@@ -253,7 +242,7 @@ const Dependents = () => {
       try {
         const deletedMember: FamilyMember = {
           ...editingItem,
-          status: 'deleted',
+          state: stateFromName('deleted'),
         }
         const updatedFamilyMembers = [...(user?.familyMembers ?? [])]
         updatedFamilyMembers[getIndex] = deletedMember
@@ -289,7 +278,7 @@ const Dependents = () => {
           lastName: values.lastName,
           relationship: values.relationship,
           residenceCountryStatus: values.residenceCountryStatus,
-          status: values.status,
+          state: stateFromName(values.status as any),
         }
         const updatedFamilyMembers = [...(user?.familyMembers ?? [])]
         updatedFamilyMembers[getIndex] = updatedMember

--- a/client/src/types/FamilyMember.ts
+++ b/client/src/types/FamilyMember.ts
@@ -1,6 +1,8 @@
+import { FamilyMemberState } from '../../../src/domain/familyMember/FamilyMemberState'
+
 export type FamilyMember = {
   firstName: string
   lastName: string
   relationship: string
-  status: 'active' | 'inactive' | 'deleted'
+  state: FamilyMemberState
 }

--- a/client/src/types/User.ts
+++ b/client/src/types/User.ts
@@ -1,3 +1,5 @@
+import { FamilyMemberState } from '../../../src/domain/familyMember/FamilyMemberState'
+
 export type Register = {
   email: string
   password: string
@@ -37,7 +39,7 @@ export type FamilyMember = {
   firstName: string
   lastName: string
   relationship: string
-  status: string
+  state: FamilyMemberState
   residenceCountryStatus:
     | 'student'
     | 'worker'

--- a/server/src/models/userModel.ts
+++ b/server/src/models/userModel.ts
@@ -5,6 +5,8 @@ import {
   Ref,
   Severity,
 } from '@typegoose/typegoose'
+import { FamilyMemberState } from '../../../src/domain/familyMember/FamilyMemberState'
+import { stateFromName } from '../../../src/domain/familyMember/states'
 
 class Infos {
   @prop({ required: true })
@@ -102,8 +104,12 @@ class FamilyMember {
   @prop({ required: true })
   public relationship!: string
 
-  @prop({ required: true, default: 'active' })
-  public status!: string //Active, Deleted,
+  @prop({
+    required: true,
+    type: () => Object,
+    default: () => stateFromName('active'),
+  })
+  public state!: FamilyMemberState //Active, Deleted,
 
   @prop({
     required: true,

--- a/server/src/routers/deathAnnoucementRouter.ts
+++ b/server/src/routers/deathAnnoucementRouter.ts
@@ -10,6 +10,7 @@ import { TransactionModel } from '../models/transactionModel'
 import { notifyAllUsers } from '../mailer'
 import { handleFailedPrelevement } from '../services/subscriptionService'
 import labels from '../common/libelles.json'
+import { ActiveState, stateFromName } from '../../../src/domain/familyMember/states'
 
 export const deathAnnouncementRouter = express.Router()
 
@@ -45,8 +46,10 @@ deathAnnouncementRouter.post(
               ? new Types.ObjectId(user._id)
               : user._id
           const nbActive =
-            user.familyMembers?.filter((member) => member.status === 'active')
-              .length || 0
+            user.familyMembers?.filter((member) => {
+              const state = stateFromName((member as any).state?.name)
+              return state instanceof ActiveState
+            }).length || 0
           const totalPersons = nbActive + 1 // +1 pour le membre principal
           const totalToDeduct = totalPersons * amountPerPerson
 

--- a/server/src/services/membershipService.ts
+++ b/server/src/services/membershipService.ts
@@ -12,6 +12,7 @@ import {
 } from '../mailer'
 import labels from '../common/libelles.json'
 import { handleFailedPrelevement } from './subscriptionService'
+import { ActiveState, stateFromName } from '../../../src/domain/familyMember/states'
 
 const calculateMembershipAmount = (
   user: DocumentType<User>,
@@ -29,7 +30,8 @@ const calculateMembershipAmount = (
 
   for (const member of user.familyMembers || []) {
     const age = currentYear - new Date(member.birthDate).getFullYear()
-    if (age >= 18 && member.status === 'active') {
+    const state = stateFromName((member as any).state?.name)
+    if (age >= 18 && state instanceof ActiveState) {
       total +=
         member.residenceCountryStatus === 'student'
           ? studentAmount

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express'
 import jwt, { JwtPayload } from 'jsonwebtoken'
 import { User, UserModel } from './models/userModel'
+import { ActiveState, stateFromName } from '../../src/domain/familyMember/states'
 import { caching } from 'cache-manager'
 import { GenerateTokenType } from './types/GenerateTokenType'
 import labels from './common/libelles.json'
@@ -174,7 +175,8 @@ export const calculateTotalPersons = (user: User): number => {
   const dependents =
     user.familyMembers?.filter((member) => {
       const age = currentYear - new Date(member.birthDate).getFullYear()
-      return age >= 18 && member.status === 'active'
+      const state = stateFromName((member as any).state?.name)
+      return age >= 18 && state instanceof ActiveState
     }) || []
 
   return includeUser + dependents.length

--- a/src/domain/familyMember/FamilyMemberState.ts
+++ b/src/domain/familyMember/FamilyMemberState.ts
@@ -1,0 +1,10 @@
+export type BadgeProps = {
+  label: string
+  variant?: 'outline' | 'destructive'
+}
+
+export abstract class FamilyMemberState {
+  constructor(public readonly name: 'active' | 'inactive' | 'deleted') {}
+  abstract isEditable(): boolean
+  abstract badgeProps(): BadgeProps
+}

--- a/src/domain/familyMember/states/ActiveState.ts
+++ b/src/domain/familyMember/states/ActiveState.ts
@@ -1,0 +1,15 @@
+import { FamilyMemberState, BadgeProps } from '../FamilyMemberState'
+
+export class ActiveState extends FamilyMemberState {
+  constructor() {
+    super('active')
+  }
+
+  isEditable(): boolean {
+    return true
+  }
+
+  badgeProps(): BadgeProps {
+    return { label: 'Actif' }
+  }
+}

--- a/src/domain/familyMember/states/DeletedState.ts
+++ b/src/domain/familyMember/states/DeletedState.ts
@@ -1,0 +1,15 @@
+import { FamilyMemberState, BadgeProps } from '../FamilyMemberState'
+
+export class DeletedState extends FamilyMemberState {
+  constructor() {
+    super('deleted')
+  }
+
+  isEditable(): boolean {
+    return false
+  }
+
+  badgeProps(): BadgeProps {
+    return { label: 'Supprimé', variant: 'destructive' }
+  }
+}

--- a/src/domain/familyMember/states/InactiveState.ts
+++ b/src/domain/familyMember/states/InactiveState.ts
@@ -1,0 +1,15 @@
+import { FamilyMemberState, BadgeProps } from '../FamilyMemberState'
+
+export class InactiveState extends FamilyMemberState {
+  constructor() {
+    super('inactive')
+  }
+
+  isEditable(): boolean {
+    return true
+  }
+
+  badgeProps(): BadgeProps {
+    return { label: 'Inactif', variant: 'outline' }
+  }
+}

--- a/src/domain/familyMember/states/index.ts
+++ b/src/domain/familyMember/states/index.ts
@@ -1,0 +1,19 @@
+import { ActiveState } from './ActiveState'
+import { InactiveState } from './InactiveState'
+import { DeletedState } from './DeletedState'
+
+export { ActiveState, InactiveState, DeletedState }
+
+export const stateFromName = (
+  name: 'active' | 'inactive' | 'deleted',
+) => {
+  switch (name) {
+    case 'inactive':
+      return new InactiveState()
+    case 'deleted':
+      return new DeletedState()
+    case 'active':
+    default:
+      return new ActiveState()
+  }
+}


### PR DESCRIPTION
## Summary
- implement FamilyMemberState with Active, Inactive and Deleted states
- migrate client and server models to use state objects instead of status strings
- update membership calculations and UI logic to leverage state behaviors

## Testing
- `cd client && npm test` *(fails: Unknown file extension ".png" and other module errors)*
- `cd server && npm test` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_e_68c0cb017c04833299798581120a289f